### PR TITLE
Refactor event handlers with React 19 hooks

### DIFF
--- a/src/components/DropdownMenu/index.js
+++ b/src/components/DropdownMenu/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useCallback, useEffectEvent } from "react"
 import { createPortal } from "react-dom"
 import { motion, AnimatePresence } from "motion/react"
 import { SPRING } from "../../utils/animations"
@@ -37,19 +37,19 @@ const DropdownMenu = ({ items }) => {
         }
     }, [isOpen])
 
+    const handleClickOutside = useEffectEvent((event) => {
+        if (
+            buttonRef.current &&
+            dropdownRef.current &&
+            !buttonRef.current.contains(event.target) &&
+            !dropdownRef.current.contains(event.target)
+        ) {
+            setIsOpen(false)
+        }
+    })
+
     useEffect(() => {
         if (!isOpen) return
-
-        const handleClickOutside = (event) => {
-            if (
-                buttonRef.current &&
-                dropdownRef.current &&
-                !buttonRef.current.contains(event.target) &&
-                !dropdownRef.current.contains(event.target)
-            ) {
-                setIsOpen(false)
-            }
-        }
 
         document.addEventListener("mousedown", handleClickOutside)
         return () =>

--- a/src/components/Gallery/index.js
+++ b/src/components/Gallery/index.js
@@ -1,10 +1,10 @@
-import { useRef, useEffect, Children, useCallback } from "react"
+import { useRef, useEffect, Children, useCallback, useEffectEvent } from "react"
 import * as styles from "./Gallery.module.scss"
 
 const Gallery = ({ children, onPageChange, onScrollProgress }) => {
     const containerRef = useRef(null)
 
-    const handleScroll = useCallback(() => {
+    const handleScroll = useEffectEvent(() => {
         if (containerRef.current) {
             const scrollLeft = containerRef.current.scrollLeft
             const pageWidth = containerRef.current.offsetWidth
@@ -15,7 +15,7 @@ const Gallery = ({ children, onPageChange, onScrollProgress }) => {
             onPageChange?.(newPage)
             onScrollProgress?.(progress)
         }
-    }, [onPageChange, onScrollProgress])
+    })
 
     useEffect(() => {
         const container = containerRef.current
@@ -23,7 +23,7 @@ const Gallery = ({ children, onPageChange, onScrollProgress }) => {
             container.addEventListener("scroll", handleScroll)
             return () => container.removeEventListener("scroll", handleScroll)
         }
-    }, [handleScroll])
+    }, [])
 
     return (
         <div className={styles.root} ref={containerRef}>

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useEffectEvent } from "react"
 import * as styles from "./Picker.module.scss"
 
 import WebApp from "@twa-dev/sdk"
@@ -19,7 +19,7 @@ const Picker = ({ items, onPickerIndex }) => {
         }
     }, [])
 
-    const handleScroll = useCallback(() => {
+    const handleScroll = useEffectEvent(() => {
         if (ticking.current) return
 
         ticking.current = true
@@ -44,7 +44,7 @@ const Picker = ({ items, onPickerIndex }) => {
 
             ticking.current = false
         })
-    }, [itemHeight, items.length, selectedIndex, onPickerIndex])
+    })
 
     useEffect(() => {
         const container = pickerRef.current
@@ -52,7 +52,7 @@ const Picker = ({ items, onPickerIndex }) => {
             container.addEventListener("scroll", handleScroll)
             return () => container.removeEventListener("scroll", handleScroll)
         }
-    }, [handleScroll])
+    }, [])
 
     useEffect(() => {
         if (selectedIndex >= 0 && selectedIndex < items.length) {


### PR DESCRIPTION
## Summary
- adopt `useEffectEvent` from React 19 to provide stable event handlers
- update DropdownMenu, Gallery and Picker components to use the new hook

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install` *(fails: tunneling socket could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0e3689c832ebea2252a1e20ddb9