### PR TITLE
Fix Cell.Text description prop

### DIFF
--- a/src/pages/UI/index.js
+++ b/src/pages/UI/index.js
@@ -75,7 +75,7 @@ const UI = () => {
                     </SectionList.Item>
                     <SectionList.Item>
                         <Cell>
-                            <Cell.Text title="Label" descrption="Subtitle" />
+                            <Cell.Text title="Label" description="Subtitle" />
                         </Cell>
                         <Cell>
                             <Cell.Text title="Label" bold />


### PR DESCRIPTION
## Summary
- fix a typo in UI page so the subtitle renders correctly

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846043675c0832ea52dbbb42969fb5e