### PR TITLE
Fix color normalization helper

### DIFF
--- a/src/utils/common/index.js
+++ b/src/utils/common/index.js
@@ -63,5 +63,5 @@ export function normalizeHex(input) {
     ctx.fillStyle = input
     ctx.fillRect(0, 0, 1, 1)
     const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
-    return rgb2hex(r, g, b)
+    return rgbTohex(r, g, b)
 }


### PR DESCRIPTION
## Summary
- fix function call in `normalizeHex`

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846043bbaa8832e8e29566e0d0c0b0c