### PR TITLE
Use lighter lottie build

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/t
 ### Motion Provider
 
 Animation features are loaded lazily using `LazyMotion` from the `motion/react` package. Components import the lightweight `m` component from `motion/react-m` to enable tree shaking and reduce bundle size.
+Lottie animations also use the light build of `lottie-web` via a webpack alias to keep the bundle small.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,9 +101,12 @@ module.exports = {
 		},
 		],
 	},
-	resolve: {
-		extensions: ['.js', '.jsx'],
-	},
+        resolve: {
+                extensions: ['.js', '.jsx'],
+                alias: {
+                        'lottie-web': 'lottie-web/build/player/lottie_light',
+                },
+        },
 	plugins: [
 		new HtmlWebpackPlugin({
 			template: './public/index.html',


### PR DESCRIPTION
## Summary
- shrink lottie-web footprint by aliasing the light build
- document lighter lottie usage in README

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68460c775bec832ea8f2baea62077989