### PR TITLE
fix: revert tabbar animations

### DIFF
--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -1,14 +1,14 @@
-import { useState, lazy, Suspense } from "react"
+import { useState } from "react"
 import * as styles from "./TabBar.module.scss"
 
-const Lottie = lazy(() => import("lottie-react"))
+import Lottie from "lottie-react"
 
 const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
     const [activeIndex, setActiveIndex] = useState(defaultIndex)
 
     const handleSegmentClick = (index) => {
         setActiveIndex(index)
-        onChange?.(index)
+        if (onChange) onChange(index)
     }
 
     return (
@@ -21,9 +21,7 @@ const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
                 >
                     <div className={styles.icon}>
                         {tab.lottieIcon ? (
-                            <Suspense fallback={tab.icon || null}>
-                                <Lottie animationData={tab.lottieIcon} />
-                            </Suspense>
+                            <Lottie animationData={tab.lottieIcon} />
                         ) : (
                             tab.icon
                         )}

--- a/src/pages/prototypes/TabBar/index.js
+++ b/src/pages/prototypes/TabBar/index.js
@@ -1,10 +1,9 @@
-import { useEffect, useState, useMemo, memo } from "react"
-import * as m from "motion/react-m"
-import { AnimatePresence } from "motion/react"
+import React, { useEffect, useState, useMemo } from "react"
+import { motion, AnimatePresence } from "motion/react"
 import { TRANSITIONS } from "../../../utils/animations"
 
 import TabBar from "../../../components/TabBar"
-import NativePageTransition from "../../../components/NativePageTransition"
+import PageTransition from "../../../components/PageTransition"
 
 import * as styles from "./TabBarPage.module.scss"
 
@@ -141,7 +140,7 @@ const TabBarPage = () => {
     }, [])
 
     return (
-        <NativePageTransition>
+        <PageTransition>
             <BackButton />
             <div className={styles.container}>
                 <AnimatePresence
@@ -150,7 +149,7 @@ const TabBarPage = () => {
                     custom={view}
                     inherit={false}
                 >
-                    <m.div
+                    <motion.div
                         initial={animationConfig.initial}
                         animate={animationConfig.animate}
                         exit={animationConfig.exit}
@@ -159,12 +158,12 @@ const TabBarPage = () => {
                         className={styles.view}
                     >
                         {content}
-                    </m.div>
+                    </motion.div>
                 </AnimatePresence>
             </div>
             <TabBar tabs={tabs} onChange={handleTabChange} />
-        </NativePageTransition>
+        </PageTransition>
     )
 }
 
-export default memo(TabBarPage)
+export default React.memo(TabBarPage)


### PR DESCRIPTION
## Summary
- revert TabBar icon loading to direct Lottie import
- switch TabBar page back to PageTransition/motion.div

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68460f5b9f6c832ead7b4664b3ad8cc7