### PR TITLE
refactor(glass): replace saturate(300%) with three tint layers

### DIFF
--- a/src/components/GlassEffect/GlassContainer.js
+++ b/src/components/GlassEffect/GlassContainer.js
@@ -8,6 +8,9 @@ const GlassContainer = ({ children, className = "", style = {}, ...rest }) => {
         return (
             <>
                 <div className={styles.glassBackground} aria-hidden="true" />
+                <div className={styles.glassTintBottom} aria-hidden="true" />
+                <div className={styles.glassTintMiddle} aria-hidden="true" />
+                <div className={styles.glassTintTop} aria-hidden="true" />
                 <div className={styles.glassShadow} aria-hidden="true" />
                 <GlassBorder />
             </>
@@ -18,6 +21,9 @@ const GlassContainer = ({ children, className = "", style = {}, ...rest }) => {
     return (
         <div className={`${styles.root} ${className}`} style={style} {...rest}>
             <div className={styles.glassBackground} aria-hidden="true" />
+            <div className={styles.glassTintBottom} aria-hidden="true" />
+            <div className={styles.glassTintMiddle} aria-hidden="true" />
+            <div className={styles.glassTintTop} aria-hidden="true" />
             <div className={styles.glassShadow} aria-hidden="true" />
             <GlassBorder />
             {children}

--- a/src/components/GlassEffect/GlassContainer.module.scss
+++ b/src/components/GlassEffect/GlassContainer.module.scss
@@ -7,7 +7,7 @@
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    backdrop-filter: saturate(300%) blur(8px);
+    backdrop-filter: blur(8px);
     z-index: 0;
     will-change: transform;
     transform: translateZ(0);
@@ -17,6 +17,35 @@
         -apple-visual-effect: -apple-system-glass-material;
         backdrop-filter: none;
     }
+}
+
+.glassTintBottom {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 0;
+    background: #333;
+    mix-blend-mode: color-dodge;
+}
+
+.glassTintMiddle {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 0;
+    background: rgb(255 255 255 / 50%);
+}
+
+.glassTintTop {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 0;
+    background: #f7f7f7;
+    mix-blend-mode: plus-darker;
 }
 
 .glassShadow {


### PR DESCRIPTION
GlassContainer now renders three additional layers above the backdrop blur:

  1. #333 with mix-blend-mode: color-dodge
  2. white 50% (no blend)
  3. #f7f7f7 with mix-blend-mode: plus-darker

The saturate(300%) on .glassBackground is removed; tinting moves to the explicit stack so it can be tuned without changing filter behavior.

Note: plus-darker is WebKit-only. Non-Safari renderers will show the top tint as plain background — acceptable in the Telegram WebApp target but worth a follow-up if other platforms need parity.