### PR TITLE
feat(tabs): grow tabs to fill, extract TabContent, own bottom spacing

### DIFF
--- a/src/components/Tabs/TabContent.js
+++ b/src/components/Tabs/TabContent.js
@@ -1,0 +1,81 @@
+import { useRef, useState } from "react"
+import PropTypes from "prop-types"
+import * as m from "motion/react-m"
+import { AnimatePresence, useReducedMotion } from "motion/react"
+
+import { useResizeObserver } from "../../hooks/useResizeObserver"
+
+const SLIDE_DISTANCE = 24
+
+const slideVariants = {
+    enter: (direction) => ({
+        x: direction > 0 ? SLIDE_DISTANCE : -SLIDE_DISTANCE,
+        opacity: 0,
+    }),
+    center: { x: 0, opacity: 1 },
+    exit: (direction) => ({
+        x: direction > 0 ? -SLIDE_DISTANCE : SLIDE_DISTANCE,
+        opacity: 0,
+    }),
+}
+
+const TabContent = ({ activeIndex, children }) => {
+    const reduceMotion = useReducedMotion()
+    const [state, setState] = useState({ prev: activeIndex, direction: 0 })
+
+    if (state.prev !== activeIndex) {
+        setState({ prev: activeIndex, direction: activeIndex - state.prev })
+    }
+    const { direction } = state
+
+    const innerRef = useRef(null)
+    const [height, setHeight] = useState(null)
+
+    useResizeObserver(innerRef, () => {
+        const el = innerRef.current
+        if (el) setHeight(el.offsetHeight)
+    })
+
+    const slideTransition = reduceMotion
+        ? { duration: 0 }
+        : { duration: 0.35, ease: [0.23, 1, 0.32, 1] }
+    const heightTransition = reduceMotion
+        ? { duration: 0 }
+        : { duration: 0.3, ease: [0.23, 1, 0.32, 1] }
+
+    return (
+        <m.div
+            style={{ overflow: "hidden" }}
+            initial={false}
+            animate={height == null ? undefined : { height }}
+            transition={heightTransition}
+        >
+            <div ref={innerRef}>
+                <AnimatePresence
+                    mode="popLayout"
+                    initial={false}
+                    custom={direction}
+                >
+                    <m.div
+                        key={activeIndex}
+                        custom={direction}
+                        variants={slideVariants}
+                        initial="enter"
+                        animate="center"
+                        exit="exit"
+                        transition={slideTransition}
+                    >
+                        {children}
+                    </m.div>
+                </AnimatePresence>
+            </div>
+        </m.div>
+    )
+}
+
+TabContent.propTypes = {
+    activeIndex: PropTypes.number.isRequired,
+    children: PropTypes.node,
+}
+
+export default TabContent

--- a/src/components/Tabs/Tabs.module.scss
+++ b/src/components/Tabs/Tabs.module.scss
@@ -57,6 +57,7 @@
 .glassRoot {
     position: relative;
     isolation: isolate;
+    margin-bottom: 16px;
     padding: 3px;
     border-radius: 100px;
     border: 0.67px solid rgb(0 0 0 / 8%);
@@ -64,7 +65,7 @@
 
 .tab {
     position: relative;
-    flex: 0 0 auto;
+    flex: 1 0 auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/components/Tabs/Tabs.showcase.js
+++ b/src/components/Tabs/Tabs.showcase.js
@@ -1,93 +1,18 @@
-import { useRef, useState } from "react"
+import { useState } from "react"
 import PropTypes from "prop-types"
-import * as m from "motion/react-m"
-import { AnimatePresence, useReducedMotion } from "motion/react"
 
-import { useResizeObserver } from "../../hooks/useResizeObserver"
 import Page from "../Page"
 import SectionList from "../SectionList"
 import Cell from "../Cells"
 import ImageAvatar from "../ImageAvatar"
 import Tabs from "./"
+import TabContent from "./TabContent"
 
 import { getAssetIcon } from "../../utils/AssetsMap"
 import { BackButton } from "../../lib/twa"
 
 import data from "./Tabs.showcase.data.json"
 import * as styles from "./Tabs.showcase.module.scss"
-
-const SLIDE_DISTANCE = 24
-
-const slideVariants = {
-    enter: (direction) => ({
-        x: direction > 0 ? SLIDE_DISTANCE : -SLIDE_DISTANCE,
-        opacity: 0,
-    }),
-    center: { x: 0, opacity: 1 },
-    exit: (direction) => ({
-        x: direction > 0 ? -SLIDE_DISTANCE : SLIDE_DISTANCE,
-        opacity: 0,
-    }),
-}
-
-const TabContent = ({ activeIndex, children }) => {
-    const reduceMotion = useReducedMotion()
-    const [state, setState] = useState({ prev: activeIndex, direction: 0 })
-
-    if (state.prev !== activeIndex) {
-        setState({ prev: activeIndex, direction: activeIndex - state.prev })
-    }
-    const { direction } = state
-
-    const innerRef = useRef(null)
-    const [height, setHeight] = useState(null)
-
-    useResizeObserver(innerRef, () => {
-        const el = innerRef.current
-        if (el) setHeight(el.offsetHeight)
-    })
-
-    const slideTransition = reduceMotion
-        ? { duration: 0 }
-        : { duration: 0.35, ease: [0.23, 1, 0.32, 1] }
-    const heightTransition = reduceMotion
-        ? { duration: 0 }
-        : { duration: 0.3, ease: [0.23, 1, 0.32, 1] }
-
-    return (
-        <m.div
-            style={{ overflow: "hidden" }}
-            initial={false}
-            animate={height == null ? undefined : { height }}
-            transition={heightTransition}
-        >
-            <div ref={innerRef}>
-                <AnimatePresence
-                    mode="popLayout"
-                    initial={false}
-                    custom={direction}
-                >
-                    <m.div
-                        key={activeIndex}
-                        custom={direction}
-                        variants={slideVariants}
-                        initial="enter"
-                        animate="center"
-                        exit="exit"
-                        transition={slideTransition}
-                    >
-                        {children}
-                    </m.div>
-                </AnimatePresence>
-            </div>
-        </m.div>
-    )
-}
-
-TabContent.propTypes = {
-    activeIndex: PropTypes.number.isRequired,
-    children: PropTypes.node,
-}
 
 const TokenList = ({ rows }) => (
     <>

--- a/src/components/Tabs/Tabs.showcase.module.scss
+++ b/src/components/Tabs/Tabs.showcase.module.scss
@@ -15,5 +15,5 @@
 }
 
 .glassHeader {
-    padding: 6px 0 8px;
+    padding: 6px 0 0;
 }


### PR DESCRIPTION
- .tab uses flex: 1 0 auto, so few tabs distribute extra width while many tabs preserve natural width and fall back to scroll.
- Glass variant root owns its 16px bottom spacing; wrappers no longer need padding-bottom (Tabs.showcase glassHeader simplified accordingly).
- Extracts the slide + height-animation wrapper from Tabs.showcase.js into src/components/Tabs/TabContent.js for reuse outside the showcase.