### PR TITLE
feat(cell): add triple-row Cell.Text via caption prop

### DIFF
--- a/src/components/Cells/Cell.module.scss
+++ b/src/components/Cells/Cell.module.scss
@@ -93,7 +93,6 @@
 		.body {
 			min-height: 52px;
 			padding: 10px var(--side-padding) 9px 0;
-			gap: 1px;
 		}
 
 		.end {
@@ -121,7 +120,6 @@
 
 		.body {
 			padding: 9px 12px 9px 0;
-			gap: 2px;
 		}
 
 		.end {

--- a/src/components/Cells/Cell.module.scss
+++ b/src/components/Cells/Cell.module.scss
@@ -93,6 +93,18 @@
 		.body {
 			min-height: 52px;
 			padding: 10px var(--side-padding) 9px 0;
+
+			> *:nth-child(2) {
+				margin-top: 1px;
+			}
+
+			> *:nth-child(3) {
+				margin-top: 1px;
+			}
+
+			&:has(> *:nth-child(3)) > *:nth-child(2) {
+				margin-top: 0;
+			}
 		}
 
 		.end {
@@ -120,6 +132,18 @@
 
 		.body {
 			padding: 9px 12px 9px 0;
+
+			> *:nth-child(2) {
+				margin-top: 2px;
+			}
+
+			> *:nth-child(3) {
+				margin-top: 1px;
+			}
+
+			&:has(> *:nth-child(3)) > *:nth-child(2) {
+				margin-top: 0;
+			}
 		}
 
 		.end {

--- a/src/components/Cells/Cells.showcase.js
+++ b/src/components/Cells/Cells.showcase.js
@@ -186,6 +186,38 @@ const CellsShowcase = () => {
                         </Cell>
                     </SectionList.Item>
 
+                    <SectionList.Item header="Triple">
+                        <Cell
+                            start={
+                                <InitialsAvatar
+                                    userId={3}
+                                    name="Thomas Andersson"
+                                />
+                            }
+                            end={<Cell.End label="+2.46" />}
+                        >
+                            <Cell.Text
+                                title="Thomas Andersson"
+                                description="Incoming transfer"
+                                caption="Mar 22 at 23:39"
+                                bold
+                            />
+                        </Cell>
+                        <Cell
+                            start={<ImageAvatar src={getAssetIcon("TON")} />}
+                            end={
+                                <Cell.End label="-100 TON" caption="$32.33" />
+                            }
+                        >
+                            <Cell.Text
+                                title="Outgoing transfer"
+                                description="To Alice"
+                                caption="Yesterday at 14:02"
+                                bold
+                            />
+                        </Cell>
+                    </SectionList.Item>
+
                     <SectionList.Item header="Combined">
                         <Cell
                             start={<ImageAvatar src={getAssetIcon("TON")} />}

--- a/src/components/Cells/components/CellText/CellText.module.scss
+++ b/src/components/Cells/components/CellText/CellText.module.scss
@@ -7,7 +7,12 @@
     }
 }
 
+.description {
+    color: var(--tg-theme-text-color);
+}
+
 .caption {
     max-height: 18px;
+    margin-top: 1px;
     color: var(--tg-theme-subtitle-text-color);
 }

--- a/src/components/Cells/components/CellText/CellText.module.scss
+++ b/src/components/Cells/components/CellText/CellText.module.scss
@@ -13,6 +13,5 @@
 
 .caption {
     max-height: 18px;
-    margin-top: 1px;
     color: var(--tg-theme-subtitle-text-color);
 }

--- a/src/components/Cells/components/CellText/index.js
+++ b/src/components/Cells/components/CellText/index.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types"
 import Text from "../../../Text"
 import * as styles from "./CellText.module.scss"
 
-const CellText = ({ type, title, description, bold }) => {
+const CellText = ({ type, title, description, caption, bold }) => {
     const weight = bold ? "medium" : "regular"
     const name = `${styles.label} ${type === "Accent" ? styles.accent : ""}`
 
@@ -14,9 +14,21 @@ const CellText = ({ type, title, description, bold }) => {
                 </Text>
             </div>
             {description && (
+                <div
+                    className={caption ? styles.description : styles.caption}
+                >
+                    <Text
+                        variant={caption ? "subheadline1" : "subheadline2"}
+                        weight="regular"
+                    >
+                        {description}
+                    </Text>
+                </div>
+            )}
+            {caption && (
                 <div className={styles.caption}>
                     <Text variant="subheadline2" weight="regular">
-                        {description}
+                        {caption}
                     </Text>
                 </div>
             )}
@@ -28,6 +40,7 @@ CellText.propTypes = {
     type: PropTypes.string,
     title: PropTypes.string,
     description: PropTypes.string,
+    caption: PropTypes.string,
     bold: PropTypes.bool,
 }
 


### PR DESCRIPTION
Adds optional caption prop to Cell.Text for a third text row. When caption is present, description switches from subheadline-2/dim to subheadline-1/primary to match the triple-row pattern; two-row cells preserve the original styling.

Spacing in cell body: title-to-description 0px, description-to-caption 1px (margin-top on caption replaces uniform body gap). Showcase gains a "Triple" section demonstrating both avatar and asset-icon variants.