### PR TITLE
fix(tabs-showcase): add 16px border-radius for material glass section

### DIFF
--- a/src/components/Tabs/Tabs.showcase.module.scss
+++ b/src/components/Tabs/Tabs.showcase.module.scss
@@ -10,6 +10,7 @@
     }
 
     :global(body.material) & {
+        border-radius: 16px;
         box-shadow: 0 0.33px 1px 0 rgb(0 0 0 / 6%);
     }
 }


### PR DESCRIPTION
The glass variant section card in Tabs.showcase had only a box-shadow on material and no border-radius, so the corners stayed sharp instead of matching the standard Material card look used elsewhere in SectionList (border-radius: 16px). Adds the missing rule.