### PR TITLE
feat(table): reusable iOS/Material data table component

### DIFF
--- a/src/components/Table/Table.module.scss
+++ b/src/components/Table/Table.module.scss
@@ -1,0 +1,53 @@
+.wrap {
+    --table-line: var(--tg-theme-section-separator-color);
+    --table-radius: 16px;
+    --table-pad: 10px 12px;
+    --table-head-bg: var(--quaternary-fill-background);
+    --table-cell-bg: transparent;
+    --table-line-width: var(--cell-separator-height, 0.33px);
+
+    width: 100%;
+    border: var(--table-line-width) solid var(--table-line);
+    border-radius: var(--table-radius);
+    overflow: hidden;
+}
+
+:global(body.material) .wrap {
+    --table-radius: 10px;
+    --table-pad: 11px;
+    --table-head-bg: var(--tg-theme-secondary-bg-color);
+    --table-cell-bg: var(--tg-theme-section-bg-color);
+}
+
+.scroll {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.cell {
+    padding: var(--table-pad);
+    background: var(--table-cell-bg);
+    color: var(--tg-theme-text-color);
+    text-align: left;
+    white-space: nowrap;
+    vertical-align: top;
+    border-right: var(--table-line-width) solid var(--table-line);
+    border-bottom: var(--table-line-width) solid var(--table-line);
+}
+
+.cell:last-child {
+    border-right: none;
+}
+
+.body tr:last-child .cell {
+    border-bottom: none;
+}
+
+.head .cell {
+    background: var(--table-head-bg);
+}

--- a/src/components/Table/Table.showcase.js
+++ b/src/components/Table/Table.showcase.js
@@ -1,0 +1,58 @@
+import Page from "../Page"
+import Table from "."
+
+import { BackButton } from "../../lib/twa"
+
+const TableShowcase = () => {
+    return (
+        <>
+            <BackButton />
+            <Page mode="primary">
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 24,
+                        padding: "24px var(--side-padding)",
+                    }}
+                >
+                    <Table
+                        head={["Property", "Value"]}
+                        rows={[
+                            ["Name", "Telegram"],
+                            ["Network", "TON"],
+                            ["Balance", "1,240.50"],
+                        ]}
+                    />
+
+                    <Table
+                        head={["Coin", "Price", "24h"]}
+                        align={["left", "right", "right"]}
+                        rows={[
+                            ["TON", "$5.20", "+2.1%"],
+                            ["USDT", "$1.00", "0.0%"],
+                            ["BTC", "$67k", "−1.4%"],
+                        ]}
+                    />
+
+                    <Table
+                        head={["Type", "Mass", "Horizon radius", "Example"]}
+                        align={["left", "left", "right", "left"]}
+                        rows={[
+                            ["Stellar", "3 – 100 ☉", "tens of km", "Cygnus X-1"],
+                            ["Intermediate", "100 – 100k ☉", "thousands of km", "—"],
+                            [
+                                "Supermassive",
+                                "millions – billions ☉",
+                                "Solar-System-sized",
+                                "Sgr A*",
+                            ],
+                        ]}
+                    />
+                </div>
+            </Page>
+        </>
+    )
+}
+
+export default TableShowcase

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,0 +1,68 @@
+import PropTypes from "prop-types"
+
+import Text from "../Text"
+import * as styles from "./Table.module.scss"
+
+const Table = ({ head = null, rows, align = [], className }) => {
+    const cellStyle = (i) => (align[i] ? { textAlign: align[i] } : undefined)
+
+    return (
+        <div className={[styles.wrap, className].filter(Boolean).join(" ")}>
+            <div className={styles.scroll}>
+                <table className={styles.table}>
+                    {head ? (
+                        <thead className={styles.head}>
+                            <tr>
+                                {head.map((cell, i) => (
+                                    <Text
+                                        key={i}
+                                        as="th"
+                                        apple={{
+                                            variant: "subheadline1",
+                                            weight: "semibold",
+                                        }}
+                                        material={{
+                                            variant: "subheadline2",
+                                            weight: "medium",
+                                        }}
+                                        className={styles.cell}
+                                        style={cellStyle(i)}
+                                    >
+                                        {cell}
+                                    </Text>
+                                ))}
+                            </tr>
+                        </thead>
+                    ) : null}
+                    <tbody className={styles.body}>
+                        {rows.map((row, r) => (
+                            <tr key={r}>
+                                {row.map((cell, i) => (
+                                    <Text
+                                        key={i}
+                                        as="td"
+                                        apple={{ variant: "subheadline1" }}
+                                        material={{ variant: "subheadline2" }}
+                                        className={styles.cell}
+                                        style={cellStyle(i)}
+                                    >
+                                        {cell}
+                                    </Text>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}
+
+Table.propTypes = {
+    head: PropTypes.arrayOf(PropTypes.node),
+    rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.node)).isRequired,
+    align: PropTypes.arrayOf(PropTypes.oneOf(["left", "center", "right"])),
+    className: PropTypes.string,
+}
+
+export default Table

--- a/src/pages/config.js
+++ b/src/pages/config.js
@@ -120,6 +120,12 @@ const config = [
                 ),
             },
             {
+                title: "Table",
+                component: lazyWithPreload(
+                    () => import("../components/Table/Table.showcase")
+                ),
+            },
+            {
                 title: "Gallery",
                 component: lazyWithPreload(
                     () => import("../components/Gallery/Gallery.showcase")


### PR DESCRIPTION
Reusable iOS/Material data table (Figma-derived). Row-oriented API (head/rows/align) rendering through the shared Text primitive; platform-adaptive styling (radius, padding, hairline grid, header tint) via CSS vars switched by skin; density-dependent hairlines matching Cell; scrollable content inside a fixed rounded frame. Added to the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)