### PR TITLE
feat(split-view): iPad-style sidebar shell for the catalog

### DIFF
--- a/src/components/CatalogList/index.js
+++ b/src/components/CatalogList/index.js
@@ -1,0 +1,49 @@
+import SectionList from "../SectionList"
+import Cell from "../Cells"
+import TransitionLink from "../Link"
+
+import config from "../../pages/config"
+import {
+    categoryToPrefix,
+    titleToSlug,
+    sortedPages,
+} from "../../pages/configHelpers"
+
+const sorted = sortedPages(config)
+
+const preload = (component) => {
+    component?.preload?.()
+}
+
+// Reusable catalog master list. Renders the config-driven page index as cells.
+// Used both as the full-screen CatalogPage (narrow) and the SplitView sidebar.
+const CatalogList = () => (
+    <SectionList>
+        {sorted.map(({ category, pages }) => {
+            const prefix = categoryToPrefix(category)
+            return (
+                <SectionList.Item header={category} key={category}>
+                    {pages.map(({ title, slug, component }) => {
+                        const resolvedSlug = slug || titleToSlug(title)
+                        const handlePreload = () => preload(component)
+                        return (
+                            <Cell
+                                as={TransitionLink}
+                                to={`/${prefix}/${resolvedSlug}`}
+                                end={<Cell.Part type="Chevron" />}
+                                key={resolvedSlug}
+                                onMouseEnter={handlePreload}
+                                onFocus={handlePreload}
+                                onTouchStart={handlePreload}
+                            >
+                                <Cell.Text title={title} />
+                            </Cell>
+                        )
+                    })}
+                </SectionList.Item>
+            )
+        })}
+    </SectionList>
+)
+
+export default CatalogList

--- a/src/components/Page/index.js
+++ b/src/components/Page/index.js
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import PropTypes from "prop-types"
 import WebApp from "../../lib/twa"
+import { useSplitViewContext } from "../SplitView/context"
 
 const { setHeaderColor, setBackgroundColor } = WebApp
 
@@ -11,6 +12,8 @@ const Page = ({
     backgroundColor,
     expandOnMount,
 }) => {
+    const { inDetailPane, setPaneBackground } = useSplitViewContext()
+
     const tgColorMapping = {
         primary: "bg_color",
         secondary: "secondary_bg_color",
@@ -36,13 +39,23 @@ const Page = ({
     }, [expandOnMount])
 
     useEffect(() => {
+        // In a SplitView detail pane the shell owns the TWA chrome and the pane
+        // background comes from CSS, so don't fight over header/background colors.
+        if (inDetailPane) return
         if (WebApp.initData) {
             setBackgroundColor(tgBackgroundColor)
             setHeaderColor(tgHeaderColor)
         } else {
             document.body.style.backgroundColor = CSSBackgroundColor
         }
-    }, [tgBackgroundColor, tgHeaderColor, CSSBackgroundColor])
+    }, [tgBackgroundColor, tgHeaderColor, CSSBackgroundColor, inDetailPane])
+
+    // In a detail pane, report the page color to the shell so the whole pane
+    // takes it (full height, including the bottom-inset area), not just content.
+    useEffect(() => {
+        if (!inDetailPane || !setPaneBackground) return
+        setPaneBackground(CSSBackgroundColor)
+    }, [inDetailPane, setPaneBackground, CSSBackgroundColor])
 
     return <>{children}</>
 }

--- a/src/components/PageTransition/PageTransition.module.scss
+++ b/src/components/PageTransition/PageTransition.module.scss
@@ -4,6 +4,14 @@
     overflow: hidden;
 }
 
+// Detail-pane variant: fill the parent column instead of the whole viewport.
+.contained {
+    position: relative;
+    inset: auto;
+    width: 100%;
+    height: 100%;
+}
+
 .scroll {
     width: 100%;
     height: 100%;

--- a/src/components/PageTransition/index.js
+++ b/src/components/PageTransition/index.js
@@ -17,11 +17,15 @@ const transition = {
     ease: EASING.MATERIAL_STANDARD,
 }
 
-const PageTransition = ({ children, bottomInset = false }) => {
+const PageTransition = ({ children, bottomInset = false, contained = false }) => {
     const [location] = useLocation()
 
+    const rootClassName = contained
+        ? `${styles.root} ${styles.contained}`
+        : styles.root
+
     return (
-        <div className={styles.root}>
+        <div className={rootClassName}>
             <AnimatePresence mode="popLayout">
                 <m.div
                     key={location}
@@ -42,6 +46,7 @@ const PageTransition = ({ children, bottomInset = false }) => {
 PageTransition.propTypes = {
     children: PropTypes.node,
     bottomInset: PropTypes.bool,
+    contained: PropTypes.bool,
 }
 
 export default PageTransition

--- a/src/components/SplitView/Placeholder.js
+++ b/src/components/SplitView/Placeholder.js
@@ -1,0 +1,14 @@
+import Text from "../Text"
+
+import * as styles from "./SplitView.module.scss"
+
+// Empty-state shown in the detail pane when no item is selected (route "/").
+const SplitViewPlaceholder = () => (
+    <div className={styles.placeholder}>
+        <Text variant="body" weight="regular">
+            Select a component
+        </Text>
+    </div>
+)
+
+export default SplitViewPlaceholder

--- a/src/components/SplitView/Placeholder.js
+++ b/src/components/SplitView/Placeholder.js
@@ -1,14 +1,26 @@
+import { useEffect } from "react"
 import Text from "../Text"
+import { useSplitViewContext } from "./context"
 
 import * as styles from "./SplitView.module.scss"
 
 // Empty-state shown in the detail pane when no item is selected (route "/").
-const SplitViewPlaceholder = () => (
-    <div className={styles.placeholder}>
-        <Text variant="body" weight="regular">
-            Select a component
-        </Text>
-    </div>
-)
+// Reports the secondary background so the pane resets after a page with a
+// primary/custom background (e.g. Table) was open in the detail before.
+const SplitViewPlaceholder = () => {
+    const { setPaneBackground } = useSplitViewContext()
+
+    useEffect(() => {
+        setPaneBackground?.("var(--tg-theme-secondary-bg-color)")
+    }, [setPaneBackground])
+
+    return (
+        <div className={styles.placeholder}>
+            <Text variant="body" weight="regular">
+                Select a component
+            </Text>
+        </div>
+    )
+}
 
 export default SplitViewPlaceholder

--- a/src/components/SplitView/SplitView.module.scss
+++ b/src/components/SplitView/SplitView.module.scss
@@ -1,0 +1,57 @@
+.root {
+    // Typical iPad split: sidebar ~1/3 of the screen, capped so it stays
+    // reasonable on wide desktop monitors.
+    --sidebar-width: clamp(300px, 33.333%, 440px);
+
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+}
+
+.sidebar {
+    flex: 0 0 auto;
+    width: var(--sidebar-width);
+    height: 100%;
+    overflow: hidden;
+    border-right: 0.5px solid var(--tg-theme-section-separator-color);
+    background: var(--tg-theme-secondary-bg-color);
+    animation: sidebar-in 0.3s cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.sidebarScroll {
+    height: 100%;
+    overflow-y: auto;
+    padding-top: calc(env(safe-area-inset-top, 0px) + var(--tg-content-safe-area-inset-top, 0px));
+    padding-left: env(safe-area-inset-left, 0);
+}
+
+.detail {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 100%;
+    overflow: hidden;
+    background: var(--tg-theme-secondary-bg-color);
+}
+
+.placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--tg-theme-hint-color);
+}
+
+@keyframes sidebar-in {
+    from {
+        opacity: 0;
+        transform: translateX(-8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/src/components/SplitView/context.js
+++ b/src/components/SplitView/context.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react"
+
+// Lets nested components know they render inside a SplitView detail pane.
+// Used by <Page> to yield TWA header/background chrome to the shell in split mode.
+const SplitViewContext = createContext({ inDetailPane: false })
+
+export const useSplitViewContext = () => useContext(SplitViewContext)
+
+export default SplitViewContext

--- a/src/components/SplitView/index.js
+++ b/src/components/SplitView/index.js
@@ -1,0 +1,67 @@
+import { useRef, useState } from "react"
+import PropTypes from "prop-types"
+import { useResizeObserver } from "../../hooks/useResizeObserver"
+import SplitViewContext from "./context"
+
+import * as styles from "./SplitView.module.scss"
+
+// Generic, presentational two-pane layout (iPad-style master/detail).
+// Purely structural: pass any nodes as Sidebar / Detail so prototypes can
+// reuse it with their own master content and local state or routing.
+const SplitView = ({ children }) => (
+    <div className={styles.root}>{children}</div>
+)
+
+const Sidebar = ({ children }) => (
+    <aside className={styles.sidebar}>
+        <div className={styles.sidebarScroll}>{children}</div>
+    </aside>
+)
+
+// The active <Page> reports its background through context so the whole pane
+// (full height, incl. the bottom-inset area) takes the page color, not just
+// the content. Falls back to the secondary color from CSS until a Page mounts.
+const Detail = ({ children }) => {
+    const [background, setBackground] = useState(null)
+    // Expose the pane's pixel width as --split-pane-width so pane-relative
+    // content (e.g. the Navigation header menu) can size against the pane
+    // instead of the viewport. A px value avoids the percentage-in-custom-
+    // property resolution gotcha. Portalled overlays (e.g. DropdownMenu) clamp
+    // to paneRef's rect so they don't spill over the sidebar.
+    const [paneWidth, setPaneWidth] = useState(null)
+    const paneRef = useRef(null)
+    useResizeObserver(paneRef, (entry) => setPaneWidth(entry.contentRect.width))
+
+    const style = {}
+    if (background) style.background = background
+    if (paneWidth != null) style["--split-pane-width"] = `${paneWidth}px`
+
+    return (
+        <SplitViewContext.Provider
+            value={{
+                inDetailPane: true,
+                setPaneBackground: setBackground,
+                paneRef,
+            }}
+        >
+            <main ref={paneRef} className={styles.detail} style={style}>
+                {children}
+            </main>
+        </SplitViewContext.Provider>
+    )
+}
+
+SplitView.propTypes = {
+    children: PropTypes.node,
+}
+Sidebar.propTypes = {
+    children: PropTypes.node,
+}
+Detail.propTypes = {
+    children: PropTypes.node,
+}
+
+SplitView.Sidebar = Sidebar
+SplitView.Detail = Detail
+
+export default SplitView

--- a/src/hooks/useMediaQuery.js
+++ b/src/hooks/useMediaQuery.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react"
+
+const getMatch = (query) => {
+    if (typeof window === "undefined" || !window.matchMedia) return false
+    return window.matchMedia(query).matches
+}
+
+// Generic CSS media-query subscription. Returns whether `query` currently matches
+// and re-renders the consumer when it flips.
+export function useMediaQuery(query) {
+    const [matches, setMatches] = useState(() => getMatch(query))
+
+    useEffect(() => {
+        if (typeof window === "undefined" || !window.matchMedia) return
+        const list = window.matchMedia(query)
+        const handleChange = () => setMatches(list.matches)
+        handleChange()
+        list.addEventListener("change", handleChange)
+        return () => list.removeEventListener("change", handleChange)
+    }, [query])
+
+    return matches
+}
+
+export default useMediaQuery

--- a/src/hooks/useSplitView.js
+++ b/src/hooks/useSplitView.js
@@ -1,0 +1,12 @@
+import { useMediaQuery } from "./useMediaQuery"
+
+// Breakpoint at which the shell switches from a single-column stack to the
+// iPad-style split layout (persistent sidebar + detail pane).
+export const SPLIT_VIEW_QUERY = "(min-width: 900px)"
+
+// Returns true when the viewport is wide enough for split-view.
+export function useSplitView() {
+    return useMediaQuery(SPLIT_VIEW_QUERY)
+}
+
+export default useSplitView

--- a/src/pages/CatalogPage/index.js
+++ b/src/pages/CatalogPage/index.js
@@ -1,45 +1,9 @@
 import Page from "../../components/Page"
-import SectionList from "../../components/SectionList"
-import Cell from "../../components/Cells"
-import TransitionLink from "../../components/Link"
-
-import config from "../config"
-import { categoryToPrefix, titleToSlug, sortedPages } from "../configHelpers"
-
-const sorted = sortedPages(config)
-
-const preload = (component) => {
-    component?.preload?.()
-}
+import CatalogList from "../../components/CatalogList"
 
 const CatalogPage = () => (
     <Page>
-        <SectionList>
-            {sorted.map(({ category, pages }) => {
-                const prefix = categoryToPrefix(category)
-                return (
-                    <SectionList.Item header={category} key={category}>
-                        {pages.map(({ title, slug, component }) => {
-                            const resolvedSlug = slug || titleToSlug(title)
-                            const handlePreload = () => preload(component)
-                            return (
-                                <Cell
-                                    as={TransitionLink}
-                                    to={`/${prefix}/${resolvedSlug}`}
-                                    end={<Cell.Part type="Chevron" />}
-                                    key={resolvedSlug}
-                                    onMouseEnter={handlePreload}
-                                    onFocus={handlePreload}
-                                    onTouchStart={handlePreload}
-                                >
-                                    <Cell.Text title={title} />
-                                </Cell>
-                            )
-                        })}
-                    </SectionList.Item>
-                )
-            })}
-        </SectionList>
+        <CatalogList />
     </Page>
 )
 

--- a/src/pages/configHelpers.js
+++ b/src/pages/configHelpers.js
@@ -24,6 +24,16 @@ export function sortedPages(config) {
     }))
 }
 
+// Routes that may render inside a SplitView detail pane. Prototypes own their
+// nested routing / page transitions / BackButton, so they stay full-screen.
+export function isSplitEligible(location) {
+    return (
+        location === "/" ||
+        location.startsWith("/showcase/") ||
+        location.startsWith("/telegram/")
+    )
+}
+
 export function flattenRoutes(config) {
     return sortedPages(config).flatMap(({ category, pages }) => {
         const prefix = categoryToPrefix(category)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,8 +75,13 @@ function AppRoutes() {
     }
 
     // Shell owns the TWA chrome in split mode; detail-pane <Page>s defer to it.
+    // The chrome <Page> is a sibling keyed on location so it re-asserts the
+    // shell header/background on every navigation (resetting anything a detail
+    // demo mutated directly, e.g. NavigationBar's color picker) without
+    // remounting SplitView or the sidebar.
     return (
-        <Page mode="secondary">
+        <>
+            <Page mode="secondary" key={location} />
             <SplitView>
                 <SplitView.Sidebar>
                     <CatalogList />
@@ -85,7 +90,7 @@ function AppRoutes() {
                     {location === "/" ? <SplitViewPlaceholder /> : stack(true)}
                 </SplitView.Detail>
             </SplitView>
-        </Page>
+        </>
     )
 }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,8 +9,14 @@ import SkinSwitcher from "../components/SkinSwitcher"
 import ErrorBoundary from "../components/ErrorBoundary"
 import RouteErrorFallback from "./RouteErrorFallback"
 
+import SplitView from "../components/SplitView"
+import SplitViewPlaceholder from "../components/SplitView/Placeholder"
+import CatalogList from "../components/CatalogList"
+import useSplitView from "../hooks/useSplitView"
+
+import Page from "../components/Page"
 import config from "../pages/config"
-import { flattenRoutes } from "../pages/configHelpers"
+import { flattenRoutes, isSplitEligible } from "../pages/configHelpers"
 import CatalogPage from "../pages/CatalogPage"
 
 const routes = flattenRoutes(config)
@@ -51,14 +57,35 @@ const Routes = () => {
 function AppRoutes() {
     const [location] = useLocation()
     const showSkinSwitcher = location.startsWith("/showcase/")
+    const isWide = useSplitView()
 
-    return (
+    const stack = (contained) => (
         <>
-            <PageTransition bottomInset={showSkinSwitcher}>
+            <PageTransition contained={contained} bottomInset={showSkinSwitcher}>
                 <Routes />
             </PageTransition>
             {showSkinSwitcher && <SkinSwitcher />}
         </>
+    )
+
+    // Narrow viewport: keep the single-column stack (also a safety net for any
+    // route that opts out of split-view via isSplitEligible).
+    if (!isWide || !isSplitEligible(location)) {
+        return stack(false)
+    }
+
+    // Shell owns the TWA chrome in split mode; detail-pane <Page>s defer to it.
+    return (
+        <Page mode="secondary">
+            <SplitView>
+                <SplitView.Sidebar>
+                    <CatalogList />
+                </SplitView.Sidebar>
+                <SplitView.Detail>
+                    {location === "/" ? <SplitViewPlaceholder /> : stack(true)}
+                </SplitView.Detail>
+            </SplitView>
+        </Page>
     )
 }
 


### PR DESCRIPTION
## Что

Инфраструктура iPad-style split-view для приложения. На широких экранах (`min-width: 900px`) каталог («главная») становится постоянным левым сайдбаром, а showcase-страницы Components/Telegram рендерятся в правой детальной панели. На узких экранах — всё как раньше, single-column, без изменений.

## Как

- **`SplitView`** (`SplitView.Sidebar` / `SplitView.Detail`) — универсальный презентационный двухпанельный компонент + `SplitViewContext`.
- **`useMediaQuery` / `useSplitView`** — адаптивный примитив, брейкпоинт 900px.
- **`CatalogList`** вынесен из `CatalogPage` и переиспользуется как мастер-список сайдбара.
- **`PageTransition`** получил вариант `contained` — переход заполняет панель, а не вьюпорт; сайдбар не перемонтируется, анимируется только деталь.
- **`Page`** в детальной панели не трогает TWA-chrome (им владеет shell) и сообщает свой фон, чтобы панель брала цвет страницы на всю высоту.
- **`isSplitEligible`** — Components/Telegram открываются в панели; **Прототипы остаются полноэкранными** (у них своя вложенная навигация / переходы / BackButton).

## Архитектура

Единый hash-location управляет всем. Сайдбар — постоянный chrome, URL и есть деталь. Никаких новых маршрутов и вложенного роутинга.

## Проверка

- Узкий (<900px): идентично текущему — каталог на весь экран, тап по ячейке → полноэкранный showcase. Регрессий нет.
- Широкий (≥900px): каталог слева, showcase справа, при навигации анимируется только панель; `/` → плейсхолдер.
- Прототипы на широком — полноэкранные (в этом PR).
- `yarn lint` и `yarn build` чистые (проверено изолированно на ветке).

## Дальше

Адаптации (пане-aware DropdownMenu/модалки/меню, прототипы в панели) — в stacked PR поверх этого.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
