### PR TITLE
feat(split-view): make prototypes & overlays pane-aware

### DIFF
--- a/src/components/DropdownMenu/dropdownUtils.js
+++ b/src/components/DropdownMenu/dropdownUtils.js
@@ -15,23 +15,31 @@ const INITIAL_POSITION = {
     originY: "0%",
 }
 
-const calculatePosition = (buttonRect, dropdownSize) => {
-    const { innerHeight, innerWidth } = window
-    const spaceBelow = innerHeight - buttonRect.bottom
-    const spaceAbove = buttonRect.top
+// Bounds to clamp the menu within: the SplitView pane's rect when open inside
+// one, the full viewport otherwise.
+export const getViewportBounds = () => ({
+    left: 0,
+    top: 0,
+    right: window.innerWidth,
+    bottom: window.innerHeight,
+})
+
+const calculatePosition = (buttonRect, dropdownSize, bounds) => {
+    const spaceBelow = bounds.bottom - buttonRect.bottom
+    const spaceAbove = buttonRect.top - bounds.top
 
     const openUpwards =
         spaceBelow < dropdownSize.height && spaceAbove > spaceBelow
+
+    const minLeft = bounds.left + VIEWPORT_PADDING
+    const minTop = bounds.top + VIEWPORT_PADDING
 
     const buttonCenterX = buttonRect.left + buttonRect.width / 2
     const rawLeft = buttonCenterX - dropdownSize.width / 2
     const left = clamp(
         rawLeft,
-        VIEWPORT_PADDING,
-        Math.max(
-            VIEWPORT_PADDING,
-            innerWidth - dropdownSize.width - VIEWPORT_PADDING
-        )
+        minLeft,
+        Math.max(minLeft, bounds.right - dropdownSize.width - VIEWPORT_PADDING)
     )
 
     const rawTop = openUpwards
@@ -39,11 +47,8 @@ const calculatePosition = (buttonRect, dropdownSize) => {
         : buttonRect.bottom + GAP
     const top = clamp(
         rawTop,
-        VIEWPORT_PADDING,
-        Math.max(
-            VIEWPORT_PADDING,
-            innerHeight - dropdownSize.height - VIEWPORT_PADDING
-        )
+        minTop,
+        Math.max(minTop, bounds.bottom - dropdownSize.height - VIEWPORT_PADDING)
     )
 
     const originXPx = clamp(buttonCenterX - left, 0, dropdownSize.width)
@@ -53,11 +58,16 @@ const calculatePosition = (buttonRect, dropdownSize) => {
     return { top, left, openUpwards, originX, originY }
 }
 
-export const useDropdownPosition = (isOpen, buttonRef, dropdownRef) =>
+export const useDropdownPosition = (
+    isOpen,
+    buttonRef,
+    dropdownRef,
+    getBounds = getViewportBounds
+) =>
     useAnchoredPosition({
         isOpen,
         triggerRef: buttonRef,
         contentRef: dropdownRef,
         initialPosition: INITIAL_POSITION,
-        calculate: calculatePosition,
+        calculate: (rect, size) => calculatePosition(rect, size, getBounds()),
     })

--- a/src/components/DropdownMenu/index.js
+++ b/src/components/DropdownMenu/index.js
@@ -6,7 +6,12 @@ import { AnimatePresence } from "motion/react"
 import { POPOVER_VARIANTS } from "../../utils/animations"
 import Text from "../Text"
 import { GlassBorder } from "../GlassEffect"
-import { useClickOutside, useDropdownPosition } from "./dropdownUtils"
+import { useSplitViewContext } from "../SplitView/context"
+import {
+    useClickOutside,
+    useDropdownPosition,
+    getViewportBounds,
+} from "./dropdownUtils"
 
 import * as styles from "./DropdownMenu.module.scss"
 
@@ -44,10 +49,19 @@ const DropdownMenu = ({ items, trigger }) => {
     const itemRefs = useRef([])
     const activeIndexRef = useRef(activeIndex)
 
+    const { paneRef } = useSplitViewContext()
+    const getBounds = () => {
+        const el = paneRef?.current
+        if (!el) return getViewportBounds()
+        const { left, top, right, bottom } = el.getBoundingClientRect()
+        return { left, top, right, bottom }
+    }
+
     const { position, isPositioned, resetPosition } = useDropdownPosition(
         isOpen,
         buttonRef,
-        dropdownRef
+        dropdownRef,
+        getBounds
     )
 
     useEffect(() => {

--- a/src/components/Gallery/Gallery.module.scss
+++ b/src/components/Gallery/Gallery.module.scss
@@ -2,7 +2,7 @@
     display: flex;
     overflow-x: scroll;
     scroll-snap-type: x mandatory;
-    width: 100vw;
+    width: 100%;
     scroll-behavior: smooth;
 }
 
@@ -13,6 +13,6 @@
 .page {
     flex: none;
     scroll-snap-align: start;
-    width: 100vw;
+    width: 100%;
 }
   

--- a/src/components/ModalView/ModalView.module.scss
+++ b/src/components/ModalView/ModalView.module.scss
@@ -2,7 +2,11 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
+
+    // 100% (not 100vw) so the overlay fills its containing block — the page's
+    // transformed scroll wrapper, i.e. the SplitView pane when inside one, or
+    // the full viewport otherwise — instead of always spanning the viewport.
+    width: 100%;
     height: 100dvh;
     display: flex;
     justify-content: center;
@@ -38,7 +42,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
+    width: 100%;
     height: 100dvh;
     background: rgb(0 0 0 / 50%);
     display: flex;
@@ -56,6 +60,13 @@
     min-height: 65dvh;
     will-change: transform;
     overflow: hidden;
+
+    // The dialog container is focused only to drive the focus trap; it never
+    // needs its own focus ring (inner controls keep theirs).
+    &:focus,
+    &:focus-visible {
+        outline: none;
+    }
 
     &.animation {
         transform: translateY(100dvh);

--- a/src/components/TextField/TextField.showcase.js
+++ b/src/components/TextField/TextField.showcase.js
@@ -5,6 +5,7 @@ import Page from "../Page"
 import TextField from "../TextField"
 import GlassContainer from "../GlassEffect"
 import GradientBackground from "../GradientBackground"
+import { useSplitViewContext } from "../SplitView/context"
 
 import patternSvg from "../../images/pattern.svg"
 import { useColorScheme } from "../../hooks/useColorScheme"
@@ -15,12 +16,14 @@ import * as styles from "./TextField.showcase.module.scss"
 function InputPage() {
     const viewportHeight = useViewportHeight()
     const colorScheme = useColorScheme()
+    const { inDetailPane } = useSplitViewContext()
 
     // Используем стабильную начальную высоту для фона
     const stableHeight =
         WebApp.viewportHeight || window.innerHeight || window.screen.height
 
-    usePreventScroll()
+    // The split-view pane scrolls itself; don't lock the global body there.
+    usePreventScroll(!inDetailPane)
 
     const gradientColors = ["#d5d88d", "#d5d88d", "#88b884", "#88b884"]
     const gradientColorsDark = ["#fec496", "#dd6cb9", "#962fbf", "#4f5bd5"]

--- a/src/components/TextField/TextField.showcase.module.scss
+++ b/src/components/TextField/TextField.showcase.module.scss
@@ -2,7 +2,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
+    width: 100%;
     z-index: 0;
     transform: translateZ(0);
     backface-visibility: hidden;

--- a/src/components/TextField/usePreventScroll.js
+++ b/src/components/TextField/usePreventScroll.js
@@ -1,7 +1,11 @@
 import { useEffect } from "react"
 
-export function usePreventScroll() {
+export function usePreventScroll(enabled = true) {
     useEffect(() => {
+        // In a SplitView detail pane the pane manages its own scroll; locking
+        // the global body would collapse the whole shell, so opt out.
+        if (!enabled) return
+
         const preventScroll = (e) => {
             e.preventDefault()
             window.scrollTo(0, 0)
@@ -30,5 +34,5 @@ export function usePreventScroll() {
             window.removeEventListener("scroll", preventScroll)
             window.removeEventListener("touchmove", preventScroll)
         }
-    }, [])
+    }, [enabled])
 }

--- a/src/pages/configHelpers.js
+++ b/src/pages/configHelpers.js
@@ -24,13 +24,15 @@ export function sortedPages(config) {
     }))
 }
 
-// Routes that may render inside a SplitView detail pane. Prototypes own their
-// nested routing / page transitions / BackButton, so they stay full-screen.
+// Routes that may render inside a SplitView detail pane. All current categories
+// are eligible; this is the single place to opt a route out (e.g. a full-bleed
+// flow that should stay full-screen).
 export function isSplitEligible(location) {
     return (
         location === "/" ||
         location.startsWith("/showcase/") ||
-        location.startsWith("/telegram/")
+        location.startsWith("/telegram/") ||
+        location.startsWith("/prototype/")
     )
 }
 

--- a/src/pages/prototypes/NewNavigation/components/NavigationPanel/NavigationPanel.module.scss
+++ b/src/pages/prototypes/NewNavigation/components/NavigationPanel/NavigationPanel.module.scss
@@ -82,7 +82,10 @@
 .items {
     display: flex;
     flex-direction: column;
-    width: calc(100vw - 36px);
+
+    // Size against the SplitView pane when open inside one; full viewport
+    // otherwise (--split-pane-width is only set by the SplitView shell).
+    width: calc(var(--split-pane-width, 100vw) - 36px);
     text-align: left;
     gap: 6px;
 }

--- a/src/pages/prototypes/NewNavigation/index.js
+++ b/src/pages/prototypes/NewNavigation/index.js
@@ -76,6 +76,9 @@ function NewNavigation() {
         document.body.style.overflow = "hidden"
         return () => {
             document.body.style.overflow = ""
+            // Restore swipes on unmount too: in split-view the prototype can be
+            // left via the sidebar without ever hitting the BackButton.
+            WebApp.enableVerticalSwipes()
         }
     }, [])
 

--- a/src/pages/prototypes/Onboarding/Onboarding.module.scss
+++ b/src/pages/prototypes/Onboarding/Onboarding.module.scss
@@ -6,7 +6,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     background: #131314;
 

--- a/src/pages/prototypes/Onboarding/index.js
+++ b/src/pages/prototypes/Onboarding/index.js
@@ -65,6 +65,9 @@ const Onboarding = () => {
 
         return () => {
             WebApp.offEvent("backButtonClicked", handleBackButton)
+            // Restore swipes on unmount too: in split-view the prototype can be
+            // left via the sidebar without ever hitting the BackButton.
+            WebApp.enableVerticalSwipes()
         }
     }, [])
 


### PR DESCRIPTION
> Stacked на #50 (`feat/split-view`). Базовая ветка PR — `feat/split-view`; мёржить после #50.

## Что

Распространяет split-view на Прототипы и делает «привязанный к вьюпорту» UI (оверлеи, модалки, выпадающие меню) уважающим ширину детальной панели, а не всего экрана.

## Изменения

- **`isSplitEligible`**: добавлен `/prototype/` — прототипы теперь открываются в панели.
- **`DropdownMenu`**: портируемое меню клампится по rect панели (`paneRef` из `SplitViewContext`), с фолбэком на вьюпорт вне панели.
- **`ModalView`**: оверлей заполняет containing block (`100vw → 100%`) — скрим затемняет только панель, не сайдбар. Убрана focus-обводка контейнера диалога.
- **`NavigationPanel`**: раскрывающееся меню заголовка (Crypto Wallet / TON Wallet) меряется от `--split-pane-width` (px от shell), а не от `100vw`.
- **`Gallery` / `Onboarding` / `Input Page`**: `100vw → 100%` (относительно containing block) — чинит горизонтальный оверфлоу в панели, в узком режиме поведение не меняется.
- **`usePreventScroll`**: не лочит глобальный `body` внутри детальной панели (иначе схлопывался бы весь shell).

## Проверка

- Прототипы в панели: Navigation (таб-бар прижат к панели), Onboarding (карусель помещается), Input Page (градиент + инпут в панели, body не залочен), Background Tests, Color Asset.
- Модалка: скрим только над панелью, лист по ширине панели, без обводки.
- Меню Navigation: раскрывается по ширине панели (CDP-замер: 817px на 853px-панели), в узком — полноширинное (444px).
- DropdownMenu showcase: меню в пределах панели.
- Узкий режим везде без регрессий (правки — no-op).
- `yarn lint` и `yarn build` чистые.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
