### PR TITLE
Revert "refactor(glass): replace saturate(300%) with three tint layers"

### DIFF
--- a/src/components/GlassEffect/GlassContainer.js
+++ b/src/components/GlassEffect/GlassContainer.js
@@ -8,9 +8,6 @@ const GlassContainer = ({ children, className = "", style = {}, ...rest }) => {
         return (
             <>
                 <div className={styles.glassBackground} aria-hidden="true" />
-                <div className={styles.glassTintBottom} aria-hidden="true" />
-                <div className={styles.glassTintMiddle} aria-hidden="true" />
-                <div className={styles.glassTintTop} aria-hidden="true" />
                 <div className={styles.glassShadow} aria-hidden="true" />
                 <GlassBorder />
             </>
@@ -21,9 +18,6 @@ const GlassContainer = ({ children, className = "", style = {}, ...rest }) => {
     return (
         <div className={`${styles.root} ${className}`} style={style} {...rest}>
             <div className={styles.glassBackground} aria-hidden="true" />
-            <div className={styles.glassTintBottom} aria-hidden="true" />
-            <div className={styles.glassTintMiddle} aria-hidden="true" />
-            <div className={styles.glassTintTop} aria-hidden="true" />
             <div className={styles.glassShadow} aria-hidden="true" />
             <GlassBorder />
             {children}

--- a/src/components/GlassEffect/GlassContainer.module.scss
+++ b/src/components/GlassEffect/GlassContainer.module.scss
@@ -7,7 +7,7 @@
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    backdrop-filter: blur(8px);
+    backdrop-filter: saturate(300%) blur(8px);
     z-index: 0;
     will-change: transform;
     transform: translateZ(0);
@@ -17,35 +17,6 @@
         -apple-visual-effect: -apple-system-glass-material;
         backdrop-filter: none;
     }
-}
-
-.glassTintBottom {
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    z-index: 0;
-    background: #333;
-    mix-blend-mode: color-dodge;
-}
-
-.glassTintMiddle {
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    z-index: 0;
-    background: rgb(255 255 255 / 50%);
-}
-
-.glassTintTop {
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    z-index: 0;
-    background: #f7f7f7;
-    mix-blend-mode: plus-darker;
 }
 
 .glassShadow {


### PR DESCRIPTION
## Что

Откат [`acf395b`](https://github.com/IlyaGrshin/wallet_animations/commit/acf395b438bacbcce890988f24865891f6487867) — `refactor(glass): replace saturate(300%) with three tint layers`.

Возвращает прежний вид стекла:
- `backdrop-filter: saturate(300%) blur(8px)` вместо просто `blur(8px)`;
- убраны три tint-слоя (`color-dodge #333`, `white 50%`, `plus-darker #f7f7f7`) и соответствующие `<div>`'ы в `GlassContainer`.

## Почему

Тинт-стек на `mix-blend-mode` (в т.ч. WebKit-only `plus-darker`) откатываем к исходному `saturate`-подходу.

## Проверка

`yarn lint` и `yarn build` чистые. Затрагивает только `GlassContainer.{js,module.scss}` (2 файла).

> Независимо от PR #50 / #51 (split-view) — ветка от `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
