### PR TITLE
docs(agents): trigger /web-animation-design skill for animation work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ The root `<body>` carries `.apple` (iOS / macOS) or `.material` (Android / Deskt
 
 ## Animation
 
+- **Invoke the `/web-animation-design` skill for any animation work** — easing, timing, duration, springs, transitions, gestures, microinteractions, `prefers-reduced-motion`, or anything that "feels janky". It carries deeper motion guidance than the rules below; the rules here are the project-specific defaults on top of it.
 - Default duration **0.2-0.3s**, hard cap **1s**
 - Animations are interruptible and input-driven; they do not block user interaction
 - Set `transform-origin` correctly (animate from trigger source); for SVG, use `<g>` wrapper with `transform-box: fill-box; transform-origin: center`


### PR DESCRIPTION
Добавляет в начало раздела `## Animation` в AGENTS.md инструкцию вызывать скилл `/web-animation-design`, когда задача касается анимаций (easing/timing/springs/transitions/gestures/`prefers-reduced-motion`).

Проектные правила остаются дефолтами поверх скилла. Только доки — `AGENTS.md`, 1 строка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)