### PR TITLE
feat: replace spoiled with in-house ParticleEffect

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "motion": "^12.40.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "spoiled": "^0.5.1",
     "wouter": "^3.10.0"
   },
   "scripts": {

--- a/src/components/ParticleEffect/ParticleEffect.module.scss
+++ b/src/components/ParticleEffect/ParticleEffect.module.scss
@@ -1,0 +1,36 @@
+.root {
+    position: relative;
+    display: inline-flex;
+    cursor: pointer;
+}
+
+.content {
+    display: inline-flex;
+    align-items: baseline;
+    transition: filter 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+// Hide via `filter: opacity()` rather than plain `opacity`: a filter flattens
+// the subtree into one buffer before applying, so GPU-composited children (e.g.
+// framer-motion digits in Calligraph) are actually dimmed. A plain ancestor
+// opacity transition leaves their separate layers lit in WebKit.
+.root.hidden .content {
+    filter: opacity(0);
+}
+
+// The canvas extends beyond the content box on every side (sized in JS by the
+// engine), giving particles room to billow. It overflows the wrapper and paints
+// over neighbouring elements by design.
+.canvas {
+    position: absolute;
+    pointer-events: none;
+}
+
+// WebGL2 unavailable: blur the value instead of clouding it, and drop the canvas.
+.root.fallback .canvas {
+    display: none;
+}
+
+.root.fallback.hidden .content {
+    filter: blur(7px);
+}

--- a/src/components/ParticleEffect/ParticleEffect.showcase.js
+++ b/src/components/ParticleEffect/ParticleEffect.showcase.js
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react"
+import PropTypes from "prop-types"
+import { Calligraph } from "calligraph"
+
+import Page from "../Page"
+import SectionList from "../SectionList"
+import Text from "../Text"
+import ParticleEffect from "."
+
+import { generateRandomBalance } from "../../utils/number"
+import { BackButton } from "../../lib/twa"
+
+function Demo({ color, children }) {
+    const [hidden, setHidden] = useState(true)
+
+    return (
+        <ParticleEffect
+            hidden={hidden}
+            color={color}
+            onClick={() => setHidden((s) => !s)}
+        >
+            {children}
+        </ParticleEffect>
+    )
+}
+
+Demo.propTypes = {
+    color: PropTypes.string,
+    children: PropTypes.node,
+}
+
+// Mirrors BalanceCard: a Calligraph number that rolls every second (frozen
+// while hidden). Use this to A/B against the static cases above.
+function LiveNumberDemo() {
+    const [hidden, setHidden] = useState(false)
+    const [balance, setBalance] = useState("30.06")
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            if (!hidden) setBalance(generateRandomBalance())
+        }, 1000)
+        return () => clearInterval(id)
+    }, [hidden])
+
+    return (
+        <ParticleEffect hidden={hidden} onClick={() => setHidden((s) => !s)}>
+            <Text variant="title1" apple={{ weight: "bold" }}>
+                <Calligraph variant="number" animation="smooth">
+                    {balance}
+                </Calligraph>
+            </Text>
+        </ParticleEffect>
+    )
+}
+
+const ParticleEffectShowcase = () => (
+    <>
+        <BackButton />
+        <Page>
+            <SectionList>
+                <SectionList.Item header="Tap to reveal / hide">
+                    <Demo>
+                        <Text variant="title1" apple={{ weight: "bold" }}>
+                            $1,234.56
+                        </Text>
+                    </Demo>
+                </SectionList.Item>
+
+                <SectionList.Item header="Live number (Calligraph, like BalanceCard)">
+                    <LiveNumberDemo />
+                </SectionList.Item>
+
+                <SectionList.Item header="Inline text">
+                    <Text variant="body">
+                        The password is{" "}
+                        <Demo>
+                            <Text variant="body">hunter2</Text>
+                        </Demo>{" "}
+                        — keep it safe.
+                    </Text>
+                </SectionList.Item>
+
+                <SectionList.Item header="On a dark surface (white particles)">
+                    <div
+                        style={{
+                            background: "#1c1c1e",
+                            padding: "24px",
+                            borderRadius: "16px",
+                            color: "#fff",
+                        }}
+                    >
+                        <Demo color="#fff">
+                            <Text variant="title1" apple={{ weight: "bold" }}>
+                                7 412 TON
+                            </Text>
+                        </Demo>
+                    </div>
+                </SectionList.Item>
+            </SectionList>
+        </Page>
+    </>
+)
+
+export default ParticleEffectShowcase

--- a/src/components/ParticleEffect/fragment.glsl
+++ b/src/components/ParticleEffect/fragment.glsl
@@ -1,0 +1,16 @@
+#version 300 es
+
+precision highp float;
+
+in float alpha;
+out vec4 fragColor;
+
+uniform vec3 color;
+
+void main() {
+  vec2 c = 2.0 * gl_PointCoord - 1.0;
+  if (dot(c, c) > 1.0) {
+    discard;
+  }
+  fragColor = vec4(color, alpha);
+}

--- a/src/components/ParticleEffect/glEngine.js
+++ b/src/components/ParticleEffect/glEngine.js
@@ -1,0 +1,248 @@
+import { linkProgram, resolveColor } from "./glUtils"
+import { renderTextMask } from "./textMask"
+
+// Simulation tuning for the "text" (text = 1) mode of the dkaraush particle
+// system, matching the demo defaults at dkaraush.github.io/particles.
+const SIM = {
+    noiseScale: 22,
+    noiseSpeed: 0.6,
+    forceMult: 0.6,
+    velocityMult: 1,
+    dampingMult: 0.9999,
+    maxVelocity: 6,
+    longevity: 1.4,
+    noiseMovement: 4,
+    timeScale: 1,
+}
+const DPR_MAX = 2
+const FADE_OUT_MS = 400
+// Particles per CSS px^2 of the WHOLE (padded) canvas, matching the demo's areal
+// density: ~7000 particles over its ~500css square = 7000 / 500^2.
+const PARTICLE_DENSITY = 0.028
+const PARTICLE_MIN = 300
+const PARTICLE_MAX = 8000
+const STRIDE = 28 // 7 floats * 4 bytes
+const ATTRIBS = [[0, 2, 0], [1, 2, 8], [2, 1, 16], [3, 1, 20], [4, 1, 24]]
+
+const UNIFORMS = [
+    "time", "deltaTime", "size", "reset", "r", "seed", "noiseScale",
+    "noiseSpeed", "dampingMult", "velocityMult", "forceMult", "longevity",
+    "maxVelocity", "noiseMovement", "color", "fadeOut", "fadeOutXY", "text",
+    "textTexture",
+]
+
+/**
+ * Builds the WebGL2 particle engine over a canvas, sized to a content element.
+ * Particles spawn on the rasterized text mask (text mode), so the cloud is
+ * shaped like the content. Runs only while covering or during the reveal
+ * fade-out; idles once fully revealed. cover() captures the (frozen) content
+ * into the mask and spawns; reveal(origin) bursts the cloud from the pointer;
+ * reveal() before any cover() is a no-op.
+ */
+export function createEngine({
+    gl,
+    canvas,
+    content,
+    color,
+    radius,
+    padding,
+    maskDilation = 0.3,
+}) {
+    const program = linkProgram(gl)
+    const loc = {}
+    for (const name of UNIFORMS) loc[name] = gl.getUniformLocation(program, name)
+
+    const maskCanvas = document.createElement("canvas")
+    const maskCtx = maskCanvas.getContext("2d")
+    const texture = gl.createTexture()
+    gl.activeTexture(gl.TEXTURE0)
+    gl.bindTexture(gl.TEXTURE_2D, texture)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    gl.useProgram(program)
+    gl.uniform1i(loc.textTexture, 0)
+
+    gl.clearColor(0, 0, 0, 0)
+    gl.enable(gl.BLEND)
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+
+    const e = {
+        buffer: null,
+        bufferIndex: 0,
+        count: 0,
+        w: 0,
+        h: 0,
+        dpr: 1,
+        radius: 0,
+        color: [1, 1, 1],
+        seed: Math.random() * 10,
+        time: 0,
+        lastDraw: 0,
+        reset: false,
+        fadeOut: false,
+        fadeOutTime: 0,
+        fadeOutXY: [0, 0],
+        covered: false,
+        text: 1, // 1 = particles spawn on the glyph mask, 0 = block fallback
+        pad: 0,
+        raf: 0,
+    }
+
+    const genBuffer = () => {
+        if (e.buffer) {
+            gl.deleteBuffer(e.buffer[0])
+            gl.deleteBuffer(e.buffer[1])
+        }
+        e.buffer = [gl.createBuffer(), gl.createBuffer()]
+        for (let i = 0; i < 2; ++i) {
+            gl.bindBuffer(gl.ARRAY_BUFFER, e.buffer[i])
+            gl.bufferData(gl.ARRAY_BUFFER, e.count * STRIDE, gl.DYNAMIC_DRAW)
+        }
+        e.bufferIndex = 0
+    }
+
+    const updateMask = () => {
+        if (e.w <= 0 || e.h <= 0) return
+        maskCanvas.width = e.w
+        maskCanvas.height = e.h
+        e.text =
+            renderTextMask(content, maskCtx, e.dpr, e.pad, maskDilation) > 0
+                ? 1
+                : 0
+        gl.activeTexture(gl.TEXTURE0)
+        gl.bindTexture(gl.TEXTURE_2D, texture)
+        gl.texImage2D(
+            gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, maskCanvas,
+        )
+        gl.generateMipmap(gl.TEXTURE_2D)
+    }
+
+    const bindAttribs = () => {
+        for (const [index, size, offset] of ATTRIBS) {
+            gl.vertexAttribPointer(index, size, gl.FLOAT, false, STRIDE, offset)
+            gl.enableVertexAttribArray(index)
+        }
+    }
+
+    const resize = () => {
+        const rect = content.getBoundingClientRect()
+        if (rect.width <= 0 || rect.height <= 0) return
+        e.dpr = Math.min(window.devicePixelRatio || 1, DPR_MAX)
+        // Headroom around the content so particles have room to billow (shader
+        // motion scales with the canvas's short side). The demo runs a ~500css
+        // square over ~48css text rows, so default to ~1x the content height
+        // per side; callers can override with the `padding` prop.
+        e.pad = padding != null ? padding : Math.round(rect.height)
+        const cssW = rect.width + 2 * e.pad
+        const cssH = rect.height + 2 * e.pad
+        // Canvas overflows the content box equally on every side.
+        canvas.style.left = canvas.style.top = `${-e.pad}px`
+        canvas.style.width = `${cssW}px`
+        canvas.style.height = `${cssH}px`
+        e.w = canvas.width = Math.floor(cssW * e.dpr)
+        e.h = canvas.height = Math.floor(cssH * e.dpr)
+        e.radius = (radius || 1.6) * e.dpr
+        e.count = Math.max(
+            PARTICLE_MIN,
+            Math.min(PARTICLE_MAX, Math.round(cssW * cssH * PARTICLE_DENSITY)),
+        )
+        e.color = resolveColor(color, content)
+        genBuffer()
+        updateMask()
+        e.reset = true
+    }
+
+    const frame = () => {
+        const now = window.performance.now()
+        const dt = Math.min((now - e.lastDraw) / 1000, 1) * SIM.timeScale
+        e.lastDraw = now
+        e.time += dt
+        if (e.fadeOut) e.fadeOutTime += (dt * 1000) / FADE_OUT_MS
+        const fadeOutT = Math.min(e.fadeOutTime, 1)
+
+        gl.viewport(0, 0, e.w, e.h)
+        gl.clear(gl.COLOR_BUFFER_BIT)
+        if (fadeOutT >= 1) {
+            e.raf = 0 // reveal finished: idle the loop
+            return
+        }
+
+        gl.useProgram(program)
+        gl.uniform1f(loc.reset, e.reset ? 1 : 0)
+        if (e.reset) {
+            e.time = 0
+            e.reset = false
+        }
+        gl.uniform1f(loc.time, e.time)
+        gl.uniform1f(loc.deltaTime, dt)
+        gl.uniform2f(loc.size, e.w, e.h)
+        gl.uniform1f(loc.seed, e.seed)
+        gl.uniform1f(loc.r, e.radius)
+        gl.uniform1f(loc.noiseScale, SIM.noiseScale)
+        gl.uniform1f(loc.noiseSpeed, SIM.noiseSpeed)
+        gl.uniform1f(loc.dampingMult, SIM.dampingMult)
+        gl.uniform1f(loc.velocityMult, SIM.velocityMult)
+        gl.uniform1f(loc.forceMult, SIM.forceMult)
+        gl.uniform1f(loc.longevity, SIM.longevity)
+        gl.uniform1f(loc.maxVelocity, SIM.maxVelocity)
+        gl.uniform1f(loc.noiseMovement, SIM.noiseMovement)
+        gl.uniform3f(loc.color, e.color[0], e.color[1], e.color[2])
+        gl.uniform1f(loc.fadeOut, fadeOutT)
+        gl.uniform2f(loc.fadeOutXY, e.fadeOutXY[0], e.fadeOutXY[1])
+        gl.uniform1f(loc.text, e.text)
+        gl.activeTexture(gl.TEXTURE0)
+        gl.bindTexture(gl.TEXTURE_2D, texture)
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, e.buffer[e.bufferIndex])
+        bindAttribs()
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, e.buffer[1 - e.bufferIndex])
+        bindAttribs()
+        gl.beginTransformFeedback(gl.POINTS)
+        gl.drawArrays(gl.POINTS, 0, e.count)
+        gl.endTransformFeedback()
+        gl.bindBuffer(gl.ARRAY_BUFFER, null)
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null)
+        e.bufferIndex = 1 - e.bufferIndex
+
+        e.raf = requestAnimationFrame(frame)
+    }
+
+    const run = () => {
+        if (e.raf) return
+        e.lastDraw = window.performance.now()
+        e.raf = requestAnimationFrame(frame)
+    }
+
+    return {
+        resize,
+        cover() {
+            e.covered = true
+            e.fadeOut = false
+            e.fadeOutTime = 0
+            updateMask()
+            e.reset = true
+            run()
+        },
+        reveal(origin) {
+            if (!e.covered) return
+            e.covered = false
+            e.fadeOut = true
+            e.fadeOutTime = 0
+            e.fadeOutXY = origin
+                ? [(origin.x + e.pad) * e.dpr, e.h - (origin.y + e.pad) * e.dpr]
+                : [e.w / 2, e.h / 2]
+            run()
+        },
+        destroy() {
+            if (e.raf) cancelAnimationFrame(e.raf)
+            if (e.buffer) {
+                gl.deleteBuffer(e.buffer[0])
+                gl.deleteBuffer(e.buffer[1])
+            }
+            gl.deleteTexture(texture)
+            gl.deleteProgram(program)
+        },
+    }
+}

--- a/src/components/ParticleEffect/glEngine.js
+++ b/src/components/ParticleEffect/glEngine.js
@@ -1,4 +1,4 @@
-import { linkProgram, resolveColor } from "./glUtils"
+import { linkProgram, resolveColor, setupGl } from "./glUtils"
 import { renderTextMask } from "./textMask"
 
 // Simulation tuning for the "text" (text = 1) mode of the dkaraush particle
@@ -54,19 +54,7 @@ export function createEngine({
 
     const maskCanvas = document.createElement("canvas")
     const maskCtx = maskCanvas.getContext("2d")
-    const texture = gl.createTexture()
-    gl.activeTexture(gl.TEXTURE0)
-    gl.bindTexture(gl.TEXTURE_2D, texture)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-    gl.useProgram(program)
-    gl.uniform1i(loc.textTexture, 0)
-
-    gl.clearColor(0, 0, 0, 0)
-    gl.enable(gl.BLEND)
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+    const texture = setupGl(gl, program, loc)
 
     const e = {
         buffer: null,
@@ -87,6 +75,8 @@ export function createEngine({
         covered: false,
         text: 1, // 1 = particles spawn on the glyph mask, 0 = block fallback
         pad: 0,
+        active: false, // covering or mid-reveal (the loop should run)
+        onscreen: true, // paused by an IntersectionObserver when scrolled away
         raf: 0,
     }
 
@@ -166,6 +156,7 @@ export function createEngine({
         gl.clear(gl.COLOR_BUFFER_BIT)
         if (fadeOutT >= 1) {
             e.raf = 0 // reveal finished: idle the loop
+            e.active = false
             return
         }
 
@@ -180,14 +171,8 @@ export function createEngine({
         gl.uniform2f(loc.size, e.w, e.h)
         gl.uniform1f(loc.seed, e.seed)
         gl.uniform1f(loc.r, e.radius)
-        gl.uniform1f(loc.noiseScale, SIM.noiseScale)
-        gl.uniform1f(loc.noiseSpeed, SIM.noiseSpeed)
-        gl.uniform1f(loc.dampingMult, SIM.dampingMult)
-        gl.uniform1f(loc.velocityMult, SIM.velocityMult)
-        gl.uniform1f(loc.forceMult, SIM.forceMult)
-        gl.uniform1f(loc.longevity, SIM.longevity)
-        gl.uniform1f(loc.maxVelocity, SIM.maxVelocity)
-        gl.uniform1f(loc.noiseMovement, SIM.noiseMovement)
+        // SIM keys map 1:1 to float uniforms of the same name (timeScale has none).
+        for (const key in SIM) if (loc[key]) gl.uniform1f(loc[key], SIM[key])
         gl.uniform3f(loc.color, e.color[0], e.color[1], e.color[2])
         gl.uniform1f(loc.fadeOut, fadeOutT)
         gl.uniform2f(loc.fadeOutXY, e.fadeOutXY[0], e.fadeOutXY[1])
@@ -210,7 +195,7 @@ export function createEngine({
     }
 
     const run = () => {
-        if (e.raf) return
+        if (e.raf || !e.onscreen) return
         e.lastDraw = window.performance.now()
         e.raf = requestAnimationFrame(frame)
     }
@@ -219,6 +204,7 @@ export function createEngine({
         resize,
         cover() {
             e.covered = true
+            e.active = true
             e.fadeOut = false
             e.fadeOutTime = 0
             updateMask()
@@ -228,12 +214,26 @@ export function createEngine({
         reveal(origin) {
             if (!e.covered) return
             e.covered = false
+            e.active = true
             e.fadeOut = true
             e.fadeOutTime = 0
             e.fadeOutXY = origin
                 ? [(origin.x + e.pad) * e.dpr, e.h - (origin.y + e.pad) * e.dpr]
                 : [e.w / 2, e.h / 2]
             run()
+        },
+        // Pause the loop while scrolled off-screen, resume if still active.
+        setOnscreen(onscreen) {
+            if (onscreen === e.onscreen) return
+            e.onscreen = onscreen
+            if (!onscreen) {
+                if (e.raf) {
+                    cancelAnimationFrame(e.raf)
+                    e.raf = 0
+                }
+            } else if (e.active) {
+                run()
+            }
         },
         destroy() {
             if (e.raf) cancelAnimationFrame(e.raf)

--- a/src/components/ParticleEffect/glUtils.js
+++ b/src/components/ParticleEffect/glUtils.js
@@ -1,0 +1,49 @@
+import VERTEX_SHADER from "./vertex.glsl?raw"
+import FRAGMENT_SHADER from "./fragment.glsl?raw"
+
+const FEEDBACK_VARYINGS = [
+    "outPosition",
+    "outVelocity",
+    "outTime",
+    "outDuration",
+    "outAlpha",
+]
+
+function compile(gl, type, source) {
+    const shader = gl.createShader(type)
+    gl.shaderSource(shader, source)
+    gl.compileShader(shader)
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        throw new Error(gl.getShaderInfoLog(shader))
+    }
+    return shader
+}
+
+export function linkProgram(gl) {
+    const vs = compile(gl, gl.VERTEX_SHADER, VERTEX_SHADER)
+    const fs = compile(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER)
+    const program = gl.createProgram()
+    gl.attachShader(program, vs)
+    gl.attachShader(program, fs)
+    gl.transformFeedbackVaryings(program, FEEDBACK_VARYINGS, gl.INTERLEAVED_ATTRIBS)
+    gl.linkProgram(program)
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(program))
+    }
+    gl.deleteShader(vs)
+    gl.deleteShader(fs)
+    return program
+}
+
+// Resolves any CSS color (or the element's computed text color) to [r,g,b] 0..1.
+export function resolveColor(input, fallbackEl) {
+    const value =
+        input || (fallbackEl ? getComputedStyle(fallbackEl).color : "#fff")
+    const c = document.createElement("canvas")
+    c.width = c.height = 1
+    const ctx = c.getContext("2d")
+    ctx.fillStyle = value
+    ctx.fillRect(0, 0, 1, 1)
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+    return [r / 255, g / 255, b / 255]
+}

--- a/src/components/ParticleEffect/glUtils.js
+++ b/src/components/ParticleEffect/glUtils.js
@@ -35,6 +35,24 @@ export function linkProgram(gl) {
     return program
 }
 
+// One-time GL setup: creates the mask texture (unit 0, mipmapped, clamped),
+// points the sampler at it, and configures alpha blending. Returns the texture.
+export function setupGl(gl, program, loc) {
+    const texture = gl.createTexture()
+    gl.activeTexture(gl.TEXTURE0)
+    gl.bindTexture(gl.TEXTURE_2D, texture)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    gl.useProgram(program)
+    gl.uniform1i(loc.textTexture, 0)
+    gl.clearColor(0, 0, 0, 0)
+    gl.enable(gl.BLEND)
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+    return texture
+}
+
 // Resolves any CSS color (or the element's computed text color) to [r,g,b] 0..1.
 export function resolveColor(input, fallbackEl) {
     const value =

--- a/src/components/ParticleEffect/index.js
+++ b/src/components/ParticleEffect/index.js
@@ -1,0 +1,100 @@
+import { useRef } from "react"
+import PropTypes from "prop-types"
+
+import { useParticles } from "./useParticles"
+
+import * as styles from "./ParticleEffect.module.scss"
+
+/**
+ * ParticleEffect - covers its children with an animated particle cloud, ported
+ * from the WebGL2 transform-feedback system at github.com/dkaraush/particles.
+ * Drop-in replacement for the previous `spoiled` <Spoiler />: same
+ * hidden / onClick / className API.
+ *
+ * @param {React.ReactNode} children - Content to hide behind the particles
+ * @param {boolean} hidden - When true, the content is covered by the cloud
+ * @param {function} onClick - Click handler (typically toggles `hidden`)
+ * @param {string} className - Extra classes for the wrapper
+ * @param {string} color - Particle color (any CSS color). Defaults to the
+ *   computed text color of the content, so the cloud reads as hidden text
+ * @param {number} radius - Particle radius in CSS px (scaled by DPR)
+ * @param {number} padding - CSS headroom around the content on every side.
+ *   Particle motion scales with the canvas size, so more headroom lets the cloud
+ *   billow softer (like the demo) instead of hugging the glyph silhouette. The
+ *   canvas overflows the content box and paints over neighbours. Defaults to ~1x
+ *   the content height
+ * @param {number} maskDilation - Fattens the glyph mask (stroke width = this x
+ *   font size) so strokes and gaps merge and the text reads less. 0 = exact
+ *   glyph shape (legible), higher = more hidden. Defaults to 0.3
+ */
+export default function ParticleEffect({
+    children,
+    hidden = false,
+    onClick,
+    className,
+    color,
+    radius,
+    padding,
+    maskDilation,
+    ...rest
+}) {
+    const wrapperRef = useRef(null)
+    const contentRef = useRef(null)
+    const canvasRef = useRef(null)
+
+    const { supported, revealOriginRef } = useParticles({
+        canvasRef,
+        contentRef,
+        hidden,
+        color,
+        radius,
+        padding,
+        maskDilation,
+    })
+
+    const handleClick = (event) => {
+        const wrapper = wrapperRef.current
+        if (wrapper) {
+            const rect = wrapper.getBoundingClientRect()
+            revealOriginRef.current = {
+                x: event.clientX - rect.left,
+                y: event.clientY - rect.top,
+            }
+        }
+        onClick?.(event)
+    }
+
+    const rootClassName = [
+        styles.root,
+        hidden && styles.hidden,
+        !supported && styles.fallback,
+        className,
+    ]
+        .filter(Boolean)
+        .join(" ")
+
+    return (
+        <span
+            ref={wrapperRef}
+            className={rootClassName}
+            onClick={handleClick}
+            {...rest}
+        >
+            <span ref={contentRef} className={styles.content} aria-hidden={hidden}>
+                {children}
+            </span>
+            <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+        </span>
+    )
+}
+
+ParticleEffect.propTypes = {
+    children: PropTypes.node,
+    hidden: PropTypes.bool,
+    onClick: PropTypes.func,
+    className: PropTypes.string,
+    color: PropTypes.string,
+    radius: PropTypes.number,
+    padding: PropTypes.number,
+    maskDilation: PropTypes.number,
+}

--- a/src/components/ParticleEffect/textMask.js
+++ b/src/components/ParticleEffect/textMask.js
@@ -1,0 +1,70 @@
+// Rasterizes the content into an alpha mask: white glyphs on a transparent
+// background. The particle shader (text = 1) spawns particles only where this
+// mask is opaque, so the cloud takes the shape of the text.
+//
+// We walk the content's text nodes and paint each at its live layout position
+// (via Range rects + computed font), so it works regardless of how the children
+// render their glyphs (plain text, Calligraph spans, etc.). Content is frozen
+// while hidden, so a single capture at cover time is stable.
+//
+// Returns the number of glyph runs painted; 0 means the caller should fall back
+// to block mode rather than render an empty (invisible) mask. `pad` is the CSS
+// headroom around the content (the canvas is larger than the content box so
+// particles have room to billow like the demo), so glyphs are offset by it.
+// `dilation` fattens the glyphs (stroke width = dilation * font size) so strokes
+// and inter-glyph gaps merge, hiding the text harder — closer to the demo's
+// solid block masks than to thin readable digits.
+export function renderTextMask(content, ctx, dpr, pad = 0, dilation = 0) {
+    const base = content.getBoundingClientRect()
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+    ctx.save()
+    ctx.scale(dpr, dpr)
+    // Clip to the visible content box. Some children (e.g. Calligraph's rolling
+    // odometer) render off-slot glyphs as absolutely-positioned, visible text
+    // nodes outside the box — clipping keeps only what is actually shown.
+    ctx.beginPath()
+    ctx.rect(pad, pad, base.width, base.height)
+    ctx.clip()
+    ctx.fillStyle = "#fff"
+    ctx.strokeStyle = "#fff"
+    ctx.lineJoin = "round"
+    ctx.textBaseline = "top"
+
+    const walker = document.createTreeWalker(content, NodeFilter.SHOW_TEXT)
+    const range = document.createRange()
+    let drawn = 0
+    let node
+    while ((node = walker.nextNode())) {
+        const text = node.nodeValue
+        if (!text || !text.trim()) continue
+        const parent = node.parentElement
+        if (!parent) continue
+
+        const cs = getComputedStyle(parent)
+        if (
+            cs.visibility === "hidden" ||
+            cs.display === "none" ||
+            cs.opacity === "0"
+        ) {
+            continue
+        }
+
+        range.selectNodeContents(node)
+        const rect = range.getBoundingClientRect()
+        if (rect.width === 0 && rect.height === 0) continue
+
+        ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+        const fontPx = parseFloat(cs.fontSize) || rect.height
+        const x = rect.left - base.left + pad
+        const y = rect.top - base.top + pad + (rect.height - fontPx) / 2
+        if (dilation > 0) {
+            ctx.lineWidth = fontPx * dilation
+            ctx.strokeText(text, x, y)
+        }
+        ctx.fillText(text, x, y)
+        drawn++
+    }
+
+    ctx.restore()
+    return drawn
+}

--- a/src/components/ParticleEffect/useParticles.js
+++ b/src/components/ParticleEffect/useParticles.js
@@ -48,8 +48,15 @@ export function useParticles({
         ro.observe(content)
         engine.resize()
 
+        // Pause the render loop while scrolled out of the viewport.
+        const io = new IntersectionObserver(([entry]) => {
+            engine.setOnscreen(entry.isIntersecting)
+        })
+        io.observe(content)
+
         return () => {
             ro.disconnect()
+            io.disconnect()
             engine.destroy()
             engineRef.current = null
         }

--- a/src/components/ParticleEffect/useParticles.js
+++ b/src/components/ParticleEffect/useParticles.js
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from "react"
+
+import { createEngine } from "./glEngine"
+
+/**
+ * Wires the WebGL2 particle engine to React lifecycle and the `hidden` prop.
+ *
+ * @returns {{ supported: boolean, revealOriginRef: object }} supported is false
+ *   when WebGL2 is unavailable (caller shows a static fallback); revealOriginRef
+ *   holds the pointer origin for the reveal burst.
+ */
+export function useParticles({
+    canvasRef,
+    contentRef,
+    hidden,
+    color,
+    radius,
+    padding,
+    maskDilation,
+}) {
+    const [supported, setSupported] = useState(true)
+    const revealOriginRef = useRef(null)
+    const engineRef = useRef(null)
+
+    useEffect(() => {
+        const canvas = canvasRef.current
+        const content = contentRef.current
+        if (!canvas || !content) return
+
+        const gl = canvas.getContext("webgl2", { premultipliedAlpha: false })
+        if (!gl) {
+            setSupported(false)
+            return
+        }
+
+        const engine = createEngine({
+            gl,
+            canvas,
+            content,
+            color,
+            radius,
+            padding,
+            maskDilation,
+        })
+        engineRef.current = engine
+
+        const ro = new ResizeObserver(() => engine.resize())
+        ro.observe(content)
+        engine.resize()
+
+        return () => {
+            ro.disconnect()
+            engine.destroy()
+            engineRef.current = null
+        }
+    }, [canvasRef, contentRef, color, radius, padding, maskDilation])
+
+    // Spawn the cloud on cover, burst it away on reveal. reveal() before any
+    // cover() is a no-op, so the initial mount stays dormant.
+    useEffect(() => {
+        const engine = engineRef.current
+        if (!engine) return
+        if (hidden) engine.cover()
+        else engine.reveal(revealOriginRef.current)
+    }, [hidden])
+
+    return { supported, revealOriginRef }
+}

--- a/src/components/ParticleEffect/vertex.glsl
+++ b/src/components/ParticleEffect/vertex.glsl
@@ -1,0 +1,205 @@
+#version 300 es
+
+precision highp float;
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 1) in vec2 inVelocity;
+layout(location = 2) in float inTime;
+layout(location = 3) in float inDuration;
+layout(location = 4) in float inAlpha;
+
+out vec2 outPosition;
+out vec2 outVelocity;
+out float outTime;
+out float outDuration;
+out float outAlpha;
+out float alpha;
+
+uniform float reset;
+uniform float time;
+uniform float deltaTime;
+uniform vec2 size;
+uniform float r;
+uniform float seed;
+uniform float noiseScale;
+uniform float noiseSpeed;
+uniform float noiseMovement;
+uniform float dampingMult;
+uniform float forceMult;
+uniform float velocityMult;
+uniform float longevity;
+uniform float maxVelocity;
+
+uniform float fadeOut;
+uniform vec2 fadeOutXY;
+
+uniform float text;
+uniform sampler2D textTexture;
+
+float rand(vec2 n) { 
+	return fract(sin(dot(n,vec2(12.9898,4.1414-seed*.42)))*43758.5453);
+}
+vec4 loop(vec4 p) {
+  p.xy = fract(p.xy / noiseScale) * noiseScale;
+  p.zw = fract(p.zw / noiseScale) * noiseScale;
+  return p;
+}
+vec3 loop(vec3 p) {
+  p.xy = fract(p.xy / noiseScale) * noiseScale;
+  return p;
+}
+float mod289(float x){return x-floor(x*(1./(289.+seed)))*(289.+seed);}
+vec4 mod289(vec4 x){return x-floor(x*(1./(289.+seed)))*(289.0+seed);}
+vec4 perm(vec4 x){return mod289(((x*34.)+1.)*x);}
+float noise(vec3 p){
+  
+  vec3 a = floor(p);
+  vec3 d = p - a;
+  d = d * d * (3. - 2. * d);
+
+  vec4 b = a.xxyy + vec4(0., 1., 0., 1.);
+  vec4 k1 = perm(loop(b.xyxy));
+  vec4 k2 = perm(loop(k1.xyxy + b.zzww));
+
+  vec4 c = k2 + a.zzzz;
+  vec4 k3 = perm(c);
+  vec4 k4 = perm(c + 1.0);
+
+  vec4 o3 = fract(k4 / 41.0) * d.z + fract(k3 / 41.0) * (1.0 - d.z);
+  vec2 o4 = o3.yw * d.x + o3.xz * (1.0 - d.x);
+
+  return o4.y * d.y + o4.x * (1.0 - d.y);
+}
+vec3 grad(vec3 p) {
+  const vec2 e = vec2(.1, .0);
+  return vec3(
+    noise(loop(p + e.xyy)) - noise(loop(p - e.xyy)),
+    noise(loop(p + e.yxy)) - noise(loop(p - e.yxy)),
+    noise(loop(p + e.yyx)) - noise(loop(p - e.yyx))
+  ) / (2.0 * e.x);
+}
+vec3 curlNoise(vec3 p) {
+  p.xy /= size;
+  p.x *= (size.x / size.y);
+  p.xy = fract(p.xy);
+  p.xy *= noiseScale;
+
+  const vec2 e = vec2(.01, .0);
+  return grad(loop(p)).yzx - vec3(
+    grad(loop(p + e.yxy)).z,
+    grad(loop(p + e.yyx)).x,
+    grad(loop(p + e.xyy)).y
+  );
+}
+
+float textAlpha(vec2 pos) {
+  vec2 uv = pos / size;
+  uv.y = 1. - uv.y;
+  return texture(textTexture, uv).a;
+}
+
+vec2 genpos() {
+  float t = fract(time / 50.) * 50.;
+  if (text > 0.) {
+    vec2 pos = vec2(-10., -10.);
+    int i = 0;
+    for (; i < 4 && textAlpha(pos * size) < .3; ++i) {
+      pos = vec2(
+        rand(vec2(42., -3.) * vec2(cos(float(gl_VertexID + i) - seed), gl_VertexID + i)),
+        rand(vec2(-3., 42.) * vec2(t * (t + float(i)), sin(float(gl_VertexID + i) + seed)))
+      );
+    }
+    return pos * size;
+  }
+  return size * vec2(
+    rand(vec2(42., -3.) * vec2(cos(float(gl_VertexID) - seed), gl_VertexID)),
+    rand(vec2(-3., 42.) * vec2(t * t, sin(float(gl_VertexID) + seed)))
+  );
+}
+
+void main() {
+  vec2 position = inPosition;
+  vec2 velocity = inVelocity;
+  float particleDuration = inDuration;
+  float particleTime = inTime + deltaTime * particleDuration / longevity;
+  float particleAlpha = inAlpha;
+
+  if (reset > 0.) {
+    particleTime = rand(vec2(-94.3, 83.9) * vec2(gl_VertexID, gl_VertexID));
+    particleDuration = .5 + 2. * rand(vec2(gl_VertexID) + seed * 32.4);
+    position = genpos();
+    velocity = vec2(0.);
+    particleAlpha = text > .5 ? particleAlpha = textAlpha(position) : 1.;
+  } else if (particleTime >= 1.) {
+    particleTime = 0.0;
+    particleDuration = .5 + 2. * rand(vec2(gl_VertexID) + position);
+    if (text > .5) {
+      position = genpos();
+      particleAlpha = textAlpha(position);
+    } else {
+      particleAlpha = 1.;
+    }
+    velocity = vec2(0.);
+  }
+
+  float textVelocityMult = 1.;
+  if (text > .5) {
+    float insideText = textVelocityMult = textAlpha(position);
+    particleAlpha = min(max(particleAlpha + (insideText - .75) * deltaTime * 3., 0.), 1.);
+    if (fadeOut > 0.) {
+      particleAlpha *= mix(1., insideText, fadeOut);
+    }
+  }
+
+  float msz = min(size.x, size.y);
+  vec2 force = normalize(curlNoise(
+    vec3(
+      position + time * (noiseMovement / 100. * msz),
+      time * noiseSpeed + rand(position) * 2.5
+    )
+  ).xy);
+
+  velocity += force * forceMult * deltaTime * msz * .1;
+  velocity *= dampingMult;
+  float vlen = length(velocity);
+  float maxVelocityPx = maxVelocity / 100. * msz;
+  if (vlen > maxVelocityPx) {
+    velocity = velocity / vlen * maxVelocityPx;
+  }
+
+  float fadeOutAlpha = 1.;
+  if (fadeOut > 0.) {
+    vec2 vector = position - fadeOutXY;
+    float dist = length(vector);
+    vec2 dir = normalize(vector);
+    float dst = .9 * max(0., 1. - max(0., dist / (max(size.x, size.y) * fadeOut) - 1.));
+    position += dir * deltaTime * 1000. * dst;
+    fadeOutAlpha = 1. - fadeOut;
+  }
+  position += velocity * velocityMult * textVelocityMult * deltaTime;
+  
+  if ((
+    position.x < 0. ||
+    position.y < 0. ||
+    position.x > size.x ||
+    position.y > size.y
+  ) && fadeOut < .1) {
+    particleTime = 0.0;
+    position = genpos();
+    particleDuration = .5 + 2. * rand(vec2(gl_VertexID) + position);
+    velocity = vec2(0.);
+  }
+
+  outPosition = position;
+  outVelocity = velocity;
+  outTime = particleTime;
+  outDuration = particleDuration;
+  outAlpha = particleAlpha;
+
+  gl_PointSize = r;
+  gl_Position = vec4((position / size * 2.0 - vec2(1.0)), 0.0, 1.0);
+
+  alpha = sin(particleTime * 3.14) * fadeOutAlpha * particleAlpha * (.6 + .4 * rand(vec2(gl_VertexID)));
+}
+
+// @dkaraush

--- a/src/pages/config.js
+++ b/src/pages/config.js
@@ -155,6 +155,15 @@ const config = [
                     () => import("../components/Snackbar/Snackbar.showcase")
                 ),
             },
+            {
+                title: "Particle Effect",
+                component: lazyWithPreload(
+                    () =>
+                        import(
+                            "../components/ParticleEffect/ParticleEffect.showcase"
+                        )
+                ),
+            },
         ],
     },
     {

--- a/src/pages/prototypes/Wallet/components/BalanceCard/index.js
+++ b/src/pages/prototypes/Wallet/components/BalanceCard/index.js
@@ -1,12 +1,12 @@
 import { useState, useEffect } from "react"
 import PropTypes from "prop-types"
 import { Calligraph } from "calligraph"
-import { Spoiler } from "spoiled"
 import * as m from "motion/react-m"
 import { AnimatePresence } from "motion/react"
 
 import Train from "../../../../../components/Train"
 import Text from "../../../../../components/Text"
+import ParticleEffect from "../../../../../components/ParticleEffect"
 import { generateRandomBalance } from "../../../../../utils/number"
 
 import * as styles from "./BalanceCard.module.scss"
@@ -84,16 +84,17 @@ export default function BalanceCard({
                 >
                     {label}
                 </Text>
-                <Spoiler
+                <ParticleEffect
                     className={styles.amount}
                     hidden={hidden}
+                    color={variant === "overlay" ? "#fff" : undefined}
                     onClick={() => setHidden((s) => !s)}
                 >
                     <span className={styles.prefix}>$</span>
                     <Calligraph variant="number" animation="smooth">
                         {balance}
                     </Calligraph>
-                </Spoiler>
+                </ParticleEffect>
                 <Train
                     divider="space"
                     onClick={() => setIsToday((prev) => !prev)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,18 +5051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spoiled@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "spoiled@npm:0.5.1"
-  dependencies:
-    colord: "npm:^2.9.3"
-  peerDependencies:
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/4a14d376250f824b5e2340a8420c9248eaf29d4887512dd938728302e35394a7f2ac483aefe2b670ffc4b939ea60ca84439f50146b5259bd9008ec7a63bb24b0
-  languageName: node
-  linkType: hard
-
 "stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
@@ -5737,7 +5725,6 @@ __metadata:
     rollup-plugin-webpack-stats: "npm:^3.1.3"
     sass: "npm:^1.100.0"
     satori: "npm:^0.26.0"
-    spoiled: "npm:^0.5.1"
     stylelint: "npm:^17.13.0"
     stylelint-config-standard-scss: "npm:^17.0.0"
     vite: "npm:7"


### PR DESCRIPTION
## Что

Убирает зависимость `spoiled` и заменяет её собственным компонентом **`ParticleEffect`** — облако частиц на WebGL2 (transform feedback), портированное с [dkaraush/particles](https://github.com/dkaraush/particles). Шейдеры лежат дословно в `vertex.glsl` / `fragment.glsl`.

## Как работает

- **Text-режим**: частицы рождаются на растеризованной маске глифов, поэтому облако повторяет форму контента. Параметры симуляции — как в демо (`noiseScale 22`, `timeScale 1`, `radius dpr*1.6`, …).
- **Настройка** через пропы: `padding` (запас холста для разлёта частиц), `maskDilation` (насколько сильно прятать текст), `color`, `radius`.
- **Производительность**: RAF-цикл крутится только пока эффект закрывает контент или раскрывается, в покое простаивает. Есть статичный fallback, если WebGL2 недоступен.
- Подключён в `BalanceCard` (вместо `<Spoiler>`) и в каталог (showcase «Particle Effect»).

## Фиксы под Calligraph

Баланс рисуется через Calligraph, что вскрыло два бага:
- Calligraph — это одометр: рендерит **все 10 цифр** колонки как видимые абсолютные ноды. Маска теперь **обрезается по боксу контента**, чтобы не захватывать закадровые цифры.
- Скрытие текста переведено с `opacity` на **`filter: opacity()`** — фильтр сплющивает поддерево, поэтому GPU-слои цифр framer-motion реально гаснут (обычный `opacity` у предка в WebKit их не затемняет).

## Проверка

- `yarn lint` (JS + SCSS) — чисто
- `yarn build` — успешно
- Визуально проверено в showcase и в Wallet (через Navigation): закрытие/раскрытие, живое число Calligraph, оба варианта (light / overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)