### PR TITLE
feat(Trading): market heatmap and live TradingView data feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@lisse/core": "0.4.0",
     "@lisse/react": "^0.4.0",
+    "@tanstack/react-virtual": "^3.14.5",
     "calligraph": "^1.4.1",
     "colorthief": "^3.4.0",
     "lottie-react": "^2.4.1",

--- a/src/components/FitText/index.js
+++ b/src/components/FitText/index.js
@@ -24,9 +24,7 @@ export default function FitText({
             const outerW = outer.clientWidth
             const innerW = inner.offsetWidth
             if (!outerW || !innerW) return
-            // `fill` caps how much of the container the content may occupy,
-            // so text in tight boxes scales down before it wedges edge to
-            // edge; content that already fits within the cap is untouched.
+            // `fill` caps how much of the container the content may occupy
             let ratio = (fill * outerW) / innerW
             if (fitHeight) {
                 const outerH = outer.clientHeight

--- a/src/components/FitText/index.js
+++ b/src/components/FitText/index.js
@@ -6,6 +6,8 @@ import * as styles from "./FitText.module.scss"
 export default function FitText({
     children,
     minScale = 0.4,
+    fitHeight = false,
+    fill = 1,
     className,
     innerClassName,
 }) {
@@ -22,7 +24,17 @@ export default function FitText({
             const outerW = outer.clientWidth
             const innerW = inner.offsetWidth
             if (!outerW || !innerW) return
-            const next = Math.max(minScale, Math.min(1, outerW / innerW))
+            // `fill` caps how much of the container the content may occupy,
+            // so text in tight boxes scales down before it wedges edge to
+            // edge; content that already fits within the cap is untouched.
+            let ratio = (fill * outerW) / innerW
+            if (fitHeight) {
+                const outerH = outer.clientHeight
+                const innerH = inner.offsetHeight
+                if (outerH && innerH)
+                    ratio = Math.min(ratio, (fill * outerH) / innerH)
+            }
+            const next = Math.max(minScale, Math.min(1, ratio))
             setScale((prev) => (Math.abs(prev - next) < 0.002 ? prev : next))
         }
 
@@ -31,7 +43,7 @@ export default function FitText({
         ro.observe(outer)
         ro.observe(inner)
         return () => ro.disconnect()
-    }, [minScale, children])
+    }, [minScale, fitHeight, fill, children])
 
     return (
         <div
@@ -54,6 +66,8 @@ export default function FitText({
 FitText.propTypes = {
     children: PropTypes.node.isRequired,
     minScale: PropTypes.number,
+    fitHeight: PropTypes.bool,
+    fill: PropTypes.number,
     className: PropTypes.string,
     innerClassName: PropTypes.string,
 }

--- a/src/hooks/useAssets.js
+++ b/src/hooks/useAssets.js
@@ -2,12 +2,10 @@ import { useSyncExternalStore } from "react"
 
 import { openQuoteStream } from "../utils/tradingViewQuotes"
 
-// TradingView's coin screener: one open-CORS request carries prices, 24h
-// deltas, volumes, categories AND logo ids for the top coins — data and
-// icons come from the same catalog, so tickers always match. The screener
-// snapshot defines the universe; live prices then stream over TradingView's
-// quote websocket (see utils/tradingViewQuotes) and are flushed into the
-// snapshot at most once per FLUSH_INTERVAL.
+// TradingView's coin screener defines the asset universe (prices, deltas,
+// volumes, categories, logo ids in one open-CORS request); live prices then
+// stream over the quote websocket and are flushed into the snapshot at most
+// once per FLUSH_INTERVAL.
 const ENDPOINT = "https://scanner.tradingview.com/coin/scan"
 const SCANNER_INTERVAL = 60_000
 const FLUSH_INTERVAL = 1_000
@@ -26,14 +24,13 @@ const REQUEST = {
     range: [0, 100],
 }
 
-// The logo catalog shares the scanner's `logoid`, so the icon URL is derived
-// straight from the row — never guessed from the ticker (HYPE != XTVCHYPE).
+// Icon URLs derive from the scanner's own `logoid` — never guessed from the
+// ticker (HYPE != XTVCHYPE).
 const LOGO_BASE = "https://s3-symbol-logo.tradingview.com"
 const logoUrl = (logoid) => (logoid ? `${LOGO_BASE}/${logoid}--big.svg` : null)
 
 // Rows keep the CoinGecko field names the screens already consume;
-// `quoteSymbol` (e.g. "CRYPTO:BTCUSD") keys the websocket ticks. `image` is
-// part of the shared contract (ColorAssetPage reads it for its accent color).
+// `quoteSymbol` keys the websocket ticks, `image` feeds ColorAssetPage.
 const mapRows = (data) =>
     data.map(({ s, d }) => ({
         quoteSymbol: s,
@@ -47,10 +44,8 @@ const mapRows = (data) =>
         categories: d[6] ?? [],
     }))
 
-// Module-level store: one scanner poll, one websocket, and one flush timer
-// shared across every subscribed screen. The snapshot persists between
-// mounts so revisits paint instantly; everything stops when the last
-// subscriber leaves.
+// Module-level store shared by every subscribed screen; the snapshot
+// persists between mounts so revisits paint instantly.
 let snapshot = { assets: null, updatedAt: null, error: null }
 let base = null // last scanner rows, before websocket ticks
 let baseAt = 0 // timestamp of the current scanner snapshot
@@ -64,10 +59,9 @@ let dirty = false
 
 const notify = () => subscribers.forEach((listener) => listener())
 
-// Live ticks win over the scanner close prices — but only while they are
-// fresher than the current snapshot. After an outage/reconnect, or once a
-// symbol goes quiet, its stale tick predates the latest scanner refresh, so
-// the scanner's current close/chp wins again until the symbol ticks anew.
+// Live ticks win over scanner closes only while fresher than the current
+// snapshot: after an outage, or once a symbol goes quiet, the scanner wins
+// again until the symbol ticks anew.
 const applyTicks = (rows) =>
     rows.map((row) => {
         const tick = ticks.get(row.quoteSymbol)
@@ -115,25 +109,24 @@ const flush = () => {
 
 const refresh = async () => {
     try {
-        // No Content-Type header on purpose: the scanner's preflight does
-        // not allow it, but a bare POST (text/plain) is a CORS "simple
-        // request" — no preflight — and the server parses the JSON body
-        // regardless.
+        // No Content-Type header on purpose: the scanner's preflight
+        // rejects it, while a bare POST is a CORS simple request and the
+        // server parses the JSON body regardless.
         const response = await fetch(ENDPOINT, {
             method: "POST",
             body: JSON.stringify(REQUEST),
         })
         const { data } = await response.json()
-        // The last subscriber may have unmounted during the await, closing the
-        // stream. Bail before reopening one that nobody owns and would leak.
+        // The last subscriber may have unmounted during the await — bail
+        // before reopening a stream nobody owns.
         if (!subscribers.size) return
         base = mapRows(data)
         baseAt = Date.now()
         ensureStream()
         publish()
     } catch (error) {
-        // Keep serving the last good snapshot; only surface the error when
-        // there is no data at all. The next tick retries anyway.
+        // Keep serving the last good snapshot; surface the error only when
+        // there is no data at all.
         if (!snapshot.assets) {
             snapshot = { assets: null, updatedAt: null, error }
             notify()
@@ -160,10 +153,8 @@ const subscribe = (listener) => {
     }
 }
 
-// Live asset feed: `assets` stays null until the first response so screens
-// can render their skeleton in place. After that the scanner refreshes the
-// universe every SCANNER_INTERVAL while websocket ticks stream prices and
-// deltas in near-realtime — the whole tab updates at once.
+// Live asset feed; `assets` stays null until the first response so screens
+// can render their skeleton in place.
 export default function useAssets() {
     return useSyncExternalStore(subscribe, () => snapshot)
 }

--- a/src/hooks/useAssets.js
+++ b/src/hooks/useAssets.js
@@ -26,14 +26,21 @@ const REQUEST = {
     range: [0, 100],
 }
 
+// The logo catalog shares the scanner's `logoid`, so the icon URL is derived
+// straight from the row — never guessed from the ticker (HYPE != XTVCHYPE).
+const LOGO_BASE = "https://s3-symbol-logo.tradingview.com"
+const logoUrl = (logoid) => (logoid ? `${LOGO_BASE}/${logoid}--big.svg` : null)
+
 // Rows keep the CoinGecko field names the screens already consume;
-// `quoteSymbol` (e.g. "CRYPTO:BTCUSD") keys the websocket ticks.
+// `quoteSymbol` (e.g. "CRYPTO:BTCUSD") keys the websocket ticks. `image` is
+// part of the shared contract (ColorAssetPage reads it for its accent color).
 const mapRows = (data) =>
     data.map(({ s, d }) => ({
         quoteSymbol: s,
         symbol: d[0]?.toLowerCase(),
         name: d[1],
         logoid: d[2],
+        image: logoUrl(d[2]),
         current_price: d[3],
         price_change_percentage_24h: d[4],
         total_volume: d[5],
@@ -46,7 +53,8 @@ const mapRows = (data) =>
 // subscriber leaves.
 let snapshot = { assets: null, updatedAt: null, error: null }
 let base = null // last scanner rows, before websocket ticks
-const ticks = new Map() // quoteSymbol -> latest streamed fields
+let baseAt = 0 // timestamp of the current scanner snapshot
+const ticks = new Map() // quoteSymbol -> latest streamed fields + `at`
 const subscribers = new Set()
 let scannerTimer = null
 let flushTimer = null
@@ -56,11 +64,14 @@ let dirty = false
 
 const notify = () => subscribers.forEach((listener) => listener())
 
-// Live ticks win over the (older) scanner close prices.
+// Live ticks win over the scanner close prices — but only while they are
+// fresher than the current snapshot. After an outage/reconnect, or once a
+// symbol goes quiet, its stale tick predates the latest scanner refresh, so
+// the scanner's current close/chp wins again until the symbol ticks anew.
 const applyTicks = (rows) =>
     rows.map((row) => {
         const tick = ticks.get(row.quoteSymbol)
-        if (!tick) return row
+        if (!tick || tick.at < baseAt) return row
         return {
             ...row,
             current_price: tick.lp ?? row.current_price,
@@ -70,7 +81,7 @@ const applyTicks = (rows) =>
     })
 
 const onTick = (name, values) => {
-    ticks.set(name, { ...ticks.get(name), ...values })
+    ticks.set(name, { ...ticks.get(name), ...values, at: Date.now() })
     dirty = true
 }
 
@@ -113,7 +124,11 @@ const refresh = async () => {
             body: JSON.stringify(REQUEST),
         })
         const { data } = await response.json()
+        // The last subscriber may have unmounted during the await, closing the
+        // stream. Bail before reopening one that nobody owns and would leak.
+        if (!subscribers.size) return
         base = mapRows(data)
+        baseAt = Date.now()
         ensureStream()
         publish()
     } catch (error) {
@@ -141,6 +156,7 @@ const subscribe = (listener) => {
         stream?.close()
         stream = null
         streamKey = ""
+        ticks.clear() // drop the stale price cache; next mount refetches
     }
 }
 

--- a/src/hooks/useAssets.js
+++ b/src/hooks/useAssets.js
@@ -1,32 +1,153 @@
-import { useEffect, useState } from "react"
+import { useSyncExternalStore } from "react"
 
-const ENDPOINT = "https://ilyagrshn.com/coingeckoApi/index.php"
+import { openQuoteStream } from "../utils/tradingViewQuotes"
 
-// Module-level cache: the request fires once and is shared across screens
-// and remounts, so revisiting a screen shows data instantly.
-let assetsPromise = null
+// TradingView's coin screener: one open-CORS request carries prices, 24h
+// deltas, volumes, categories AND logo ids for the top coins — data and
+// icons come from the same catalog, so tickers always match. The screener
+// snapshot defines the universe; live prices then stream over TradingView's
+// quote websocket (see utils/tradingViewQuotes) and are flushed into the
+// snapshot at most once per FLUSH_INTERVAL.
+const ENDPOINT = "https://scanner.tradingview.com/coin/scan"
+const SCANNER_INTERVAL = 60_000
+const FLUSH_INTERVAL = 1_000
 
-const loadAssets = () => {
-    assetsPromise ??= fetch(ENDPOINT).then((response) => response.json())
-    return assetsPromise
+const REQUEST = {
+    columns: [
+        "base_currency",
+        "base_currency_desc",
+        "base_currency_logoid",
+        "close",
+        "24h_close_change|5",
+        "24h_vol_cmc",
+        "crypto_common_categories",
+    ],
+    sort: { sortBy: "crypto_total_rank", sortOrder: "asc" },
+    range: [0, 100],
 }
 
-// Stateful loader: `assets` stays null until the fetch resolves, so screens
-// can render their skeleton in the same tree and reveal it in place (see
-// Skeleton) instead of swapping out a Suspense fallback.
-export default function useAssets() {
-    const [state, setState] = useState({ assets: null, error: null })
+// Rows keep the CoinGecko field names the screens already consume;
+// `quoteSymbol` (e.g. "CRYPTO:BTCUSD") keys the websocket ticks.
+const mapRows = (data) =>
+    data.map(({ s, d }) => ({
+        quoteSymbol: s,
+        symbol: d[0]?.toLowerCase(),
+        name: d[1],
+        logoid: d[2],
+        current_price: d[3],
+        price_change_percentage_24h: d[4],
+        total_volume: d[5],
+        categories: d[6] ?? [],
+    }))
 
-    useEffect(() => {
-        let active = true
-        loadAssets().then(
-            (assets) => active && setState({ assets, error: null }),
-            (error) => active && setState({ assets: null, error })
-        )
-        return () => {
-            active = false
+// Module-level store: one scanner poll, one websocket, and one flush timer
+// shared across every subscribed screen. The snapshot persists between
+// mounts so revisits paint instantly; everything stops when the last
+// subscriber leaves.
+let snapshot = { assets: null, updatedAt: null, error: null }
+let base = null // last scanner rows, before websocket ticks
+const ticks = new Map() // quoteSymbol -> latest streamed fields
+const subscribers = new Set()
+let scannerTimer = null
+let flushTimer = null
+let stream = null
+let streamKey = ""
+let dirty = false
+
+const notify = () => subscribers.forEach((listener) => listener())
+
+// Live ticks win over the (older) scanner close prices.
+const applyTicks = (rows) =>
+    rows.map((row) => {
+        const tick = ticks.get(row.quoteSymbol)
+        if (!tick) return row
+        return {
+            ...row,
+            current_price: tick.lp ?? row.current_price,
+            price_change_percentage_24h:
+                tick.chp ?? row.price_change_percentage_24h,
         }
-    }, [])
+    })
 
-    return state
+const onTick = (name, values) => {
+    ticks.set(name, { ...ticks.get(name), ...values })
+    dirty = true
+}
+
+// (Re)subscribe the quote stream when the universe actually changes.
+const ensureStream = () => {
+    const key = base.map((row) => row.quoteSymbol).join(",")
+    if (key === streamKey) return
+    stream?.close()
+    stream = openQuoteStream({
+        symbols: base.map((row) => row.quoteSymbol),
+        fields: ["lp", "chp"],
+        onTick,
+    })
+    streamKey = key
+}
+
+const publish = () => {
+    snapshot = {
+        assets: applyTicks(base),
+        updatedAt: new Date(),
+        error: null,
+    }
+    notify()
+}
+
+const flush = () => {
+    if (!dirty || !base) return
+    dirty = false
+    publish()
+}
+
+const refresh = async () => {
+    try {
+        // No Content-Type header on purpose: the scanner's preflight does
+        // not allow it, but a bare POST (text/plain) is a CORS "simple
+        // request" — no preflight — and the server parses the JSON body
+        // regardless.
+        const response = await fetch(ENDPOINT, {
+            method: "POST",
+            body: JSON.stringify(REQUEST),
+        })
+        const { data } = await response.json()
+        base = mapRows(data)
+        ensureStream()
+        publish()
+    } catch (error) {
+        // Keep serving the last good snapshot; only surface the error when
+        // there is no data at all. The next tick retries anyway.
+        if (!snapshot.assets) {
+            snapshot = { assets: null, updatedAt: null, error }
+            notify()
+        }
+    }
+}
+
+const subscribe = (listener) => {
+    subscribers.add(listener)
+    if (subscribers.size === 1) {
+        refresh()
+        scannerTimer = setInterval(refresh, SCANNER_INTERVAL)
+        flushTimer = setInterval(flush, FLUSH_INTERVAL)
+    }
+    return () => {
+        subscribers.delete(listener)
+        if (subscribers.size) return
+        clearInterval(scannerTimer)
+        clearInterval(flushTimer)
+        stream?.close()
+        stream = null
+        streamKey = ""
+    }
+}
+
+// Live asset feed: `assets` stays null until the first response so screens
+// can render their skeleton in place. After that the scanner refreshes the
+// universe every SCANNER_INTERVAL while websocket ticks stream prices and
+// deltas in near-realtime — the whole tab updates at once.
+export default function useAssets() {
+    return useSyncExternalStore(subscribe, () => snapshot)
 }

--- a/src/pages/prototypes/Trading/Trading.module.scss
+++ b/src/pages/prototypes/Trading/Trading.module.scss
@@ -8,30 +8,3 @@
 .error {
     color: var(--tg-theme-subtitle-text-color);
 }
-
-// Delta color rides the wrapper (Text [variant] inherits), per convention.
-.delta {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 2px;
-
-    &.up {
-        color: var(--text-confirm-color);
-    }
-
-    &.down {
-        color: var(--tg-theme-destructive-text-color);
-    }
-
-    // The skeleton hides text by painting it transparent, but the delta's own
-    // up/down color overrides that and bleeds through the translucent bar.
-    // Yield to the redaction while the row loads so the bar fully masks the
-    // arrow and its odometer. Must be color, not opacity: ancestor opacity
-    // doesn't dim Calligraph in WebKit.
-    :global([data-skeleton]) & {
-        &.up,
-        &.down {
-            color: transparent;
-        }
-    }
-}

--- a/src/pages/prototypes/Trading/Trading.module.scss
+++ b/src/pages/prototypes/Trading/Trading.module.scss
@@ -8,3 +8,18 @@
 .error {
     color: var(--tg-theme-subtitle-text-color);
 }
+
+// Delta color rides the wrapper (Text [variant] inherits), per convention.
+.delta {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 2px;
+
+    &.up {
+        color: var(--text-confirm-color);
+    }
+
+    &.down {
+        color: var(--tg-theme-destructive-text-color);
+    }
+}

--- a/src/pages/prototypes/Trading/Trading.module.scss
+++ b/src/pages/prototypes/Trading/Trading.module.scss
@@ -22,4 +22,16 @@
     &.down {
         color: var(--tg-theme-destructive-text-color);
     }
+
+    // The skeleton hides text by painting it transparent, but the delta's own
+    // up/down color overrides that and bleeds through the translucent bar.
+    // Yield to the redaction while the row loads so the bar fully masks the
+    // arrow and its odometer. Must be color, not opacity: ancestor opacity
+    // doesn't dim Calligraph in WebKit.
+    :global([data-skeleton]) & {
+        &.up,
+        &.down {
+            color: transparent;
+        }
+    }
 }

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/AssetHeatmap.module.scss
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/AssetHeatmap.module.scss
@@ -1,0 +1,113 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    color: var(--tg-theme-text-color);
+}
+
+// The map clips its own rounded corners (radius mirrors the sibling section
+// cards): flat 8px tiles run to the edges, and the clip shaves the corner
+// tiles to the section radius so the block reads as one rounded card.
+.map {
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 1074 / 743;
+
+    :global(body.apple) & {
+        border-radius: 26px;
+    }
+
+    :global(body.material) & {
+        border-radius: 16px;
+    }
+}
+
+// Ghost surface for the whole map while the assets request loads.
+.pending {
+    background-color: var(--tg-theme-section-bg-color);
+}
+
+// Bleeds the tile layer past the clip by one tile-border width, so the
+// outer transparent borders fall outside the rounded edge and the edge
+// tiles sit flush against it; only the inner gaps remain visible.
+.tiles {
+    position: absolute;
+    inset: -1.5px;
+}
+
+// Flat 8px tiles; the transparent border + padding-box clip carves the gap
+// between them, and the map's own clip rounds the block's outer corners.
+.tile {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 4px;
+    border: 1.5px solid transparent;
+    border-radius: 8px;
+    background-clip: padding-box;
+    color: #fff;
+    text-align: center;
+    letter-spacing: -0.02em;
+
+    // Labels sit inside fixed-height treemap marks; the type ramp's airy
+    // line heights clip two-line labels in the shortest tiles. Needs
+    // !important to outrank body.apple [variant=...] from the Text styles.
+    [variant] {
+        line-height: 1.1 !important;
+    }
+}
+
+.fit {
+    height: 100%;
+}
+
+.labels {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+// Diverging scale anchored to the app's semantic tokens: hue follows
+// whatever the active Telegram theme supplies, while OKLCH pins lightness
+// and chroma per strength tier so the ramp stays consistent (values taken
+// from the reference widget's palette). Hex fallbacks cover engines without
+// relative color syntax. The percent label on each tile carries the value
+// redundantly.
+.gain1 {
+    background-color: #67ba84;
+    background-color: oklch(from var(--text-confirm-color) 72% 0.115 h);
+}
+
+.gain2 {
+    background-color: #459757;
+    background-color: oklch(from var(--text-confirm-color) 61% 0.125 h);
+}
+
+.gain3 {
+    background-color: #2d6824;
+    background-color: oklch(from var(--text-confirm-color) 46% 0.12 h);
+}
+
+.loss1 {
+    background-color: #e78383;
+    background-color: oklch(
+        from var(--tg-theme-destructive-text-color) 72% 0.125 h
+    );
+}
+
+.loss2 {
+    background-color: #df4841;
+    background-color: oklch(
+        from var(--tg-theme-destructive-text-color) 61% 0.19 h
+    );
+}
+
+.loss3 {
+    background-color: #911c12;
+    background-color: oklch(
+        from var(--tg-theme-destructive-text-color) 43% 0.155 h
+    );
+}

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/AssetHeatmap.module.scss
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/AssetHeatmap.module.scss
@@ -4,10 +4,10 @@
     color: var(--tg-theme-text-color);
 }
 
-// The map clips its own rounded corners (radius mirrors the sibling section
-// cards): flat 8px tiles run to the edges, and the clip shaves the corner
-// tiles to the section radius so the block reads as one rounded card.
+// Query container for the tiles' cqw font sizes; clips the flat tiles to
+// the section radius so the block reads as one rounded card.
 .map {
+    container-type: inline-size;
     position: relative;
     overflow: hidden;
     aspect-ratio: 1074 / 743;
@@ -26,16 +26,14 @@
     background-color: var(--tg-theme-section-bg-color);
 }
 
-// Bleeds the tile layer past the clip by one tile-border width, so the
-// outer transparent borders fall outside the rounded edge and the edge
-// tiles sit flush against it; only the inner gaps remain visible.
+// Bleed by one tile-border width: the outer transparent borders fall
+// outside the clip, so edge tiles sit flush and only inner gaps show.
 .tiles {
     position: absolute;
     inset: -1.5px;
 }
 
-// Flat 8px tiles; the transparent border + padding-box clip carves the gap
-// between them, and the map's own clip rounds the block's outer corners.
+// The transparent border + padding-box clip carves the inter-tile gap.
 .tile {
     position: absolute;
     display: flex;
@@ -51,16 +49,28 @@
     text-align: center;
     letter-spacing: -0.02em;
 
-    // Labels sit inside fixed-height treemap marks; the type ramp's airy
-    // line heights clip two-line labels in the shortest tiles. Needs
-    // !important to outrank body.apple [variant=...] from the Text styles.
+    // --fit comes precomputed from the rect geometry (index.js); the ramp
+    // size doubles as the no-container-units fallback and the cap, the 5px
+    // floor clips text instead of vanishing it.
+    font-size: 14px;
+
+    // Proportional digits would wiggle the centered line on every tick.
+    font-variant-numeric: tabular-nums;
+
+    // Revisit snapshots and first-second websocket corrections repaint
+    // tones right after mount — crossfade instead of snapping.
+    transition: background-color 0.45s ease;
+
+    @supports (font-size: 1cqw) {
+        font-size: clamp(5px, var(--fit), 14px);
+    }
+
+    // Ramp font sizes and airy line heights must yield to the fitted size;
+    // !important outranks body.apple [variant=...] from the Text styles.
     [variant] {
+        font-size: inherit !important;
         line-height: 1.1 !important;
     }
-}
-
-.fit {
-    height: 100%;
 }
 
 .labels {
@@ -70,12 +80,14 @@
     gap: 2px;
 }
 
-// Diverging scale anchored to the app's semantic tokens: hue follows
-// whatever the active Telegram theme supplies, while OKLCH pins lightness
-// and chroma per strength tier so the ramp stays consistent (values taken
-// from the reference widget's palette). Hex fallbacks cover engines without
-// relative color syntax. The percent label on each tile carries the value
-// redundantly.
+// Secondary to the ticker; mirrors CHANGE_SCALE in index.js.
+.change {
+    font-size: 0.85em;
+}
+
+// Diverging scale: hue follows the theme tokens, OKLCH pins lightness and
+// chroma per tier (reference palette); hex covers engines without relative
+// color syntax.
 .gain1 {
     background-color: #67ba84;
     background-color: oklch(from var(--text-confirm-color) 72% 0.115 h);

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
@@ -134,7 +134,7 @@ const HeatmapTile = ({ symbol, change, x, y, w, h }) => {
                 "--fit": `${fit.toFixed(3)}cqw`,
             }}
         >
-            <span className={styles.labels}>
+            <div className={styles.labels}>
                 <Text
                     apple={{ variant: "subheadline2", weight: "semibold" }}
                     material={{ variant: "subheadline2", weight: "medium" }}
@@ -142,16 +142,16 @@ const HeatmapTile = ({ symbol, change, x, y, w, h }) => {
                     {symbol}
                 </Text>
                 {showChange && (
-                    <span className={styles.change}>
+                    <div className={styles.change}>
                         <Text
                             apple={{ variant: "subheadline2" }}
                             material={{ variant: "subheadline2" }}
                         >
                             {label}
                         </Text>
-                    </span>
+                    </div>
                 )}
-            </span>
+            </div>
         </div>
     )
 }

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
@@ -1,0 +1,171 @@
+import PropTypes from "prop-types"
+import { Calligraph } from "calligraph"
+
+import Text from "../../../../../components/Text"
+import FitText from "../../../../../components/FitText"
+import SectionHeader from "../../../../../components/SectionHeader"
+import Skeleton from "../../../../../components/Skeleton"
+
+import useAssets from "../../../../../hooks/useAssets"
+
+import { squarify } from "./treemap"
+
+import * as styles from "./AssetHeatmap.module.scss"
+
+const cx = (...classes) => classes.filter(Boolean).join(" ")
+
+const MAP_ASPECT = 1074 / 743
+const TOP_COUNT = 30
+
+// Area compression exponent. BTC and ETH out-trade the tail by ~500x and
+// would swallow the map raw; 0.5 still hands them a third of it, while 0.3
+// flattens the hierarchy into near-equal tiles. 0.4 keeps the dominance
+// readable without crushing the tail.
+const AREA_EXPONENT = 0.4
+
+// Tiles shorter or narrower than these fractions of the map drop the
+// percent line: the ticker alone gets the room and stays legible.
+const MIN_CHANGE_HEIGHT = 13
+const MIN_CHANGE_WIDTH = 9
+
+// Pegged assets sit at ~0% by construction, yet dominate turnover (USDT is
+// the single biggest volume), so they would fill the map with meaningless
+// near-flat tiles — same reasoning as excluding money-market funds from a
+// stock heatmap. The screener tags them, no hand-made ticker list needed.
+const isStablecoin = (asset) => asset.categories.includes("stablecoins")
+
+// useAssets rows -> heatmap rows, largest first.
+const selectHeatmapAssets = (assets) =>
+    assets
+        .filter(
+            (asset) =>
+                !isStablecoin(asset) &&
+                asset.price_change_percentage_24h !== null &&
+                asset.total_volume > 0
+        )
+        .sort((a, b) => b.total_volume - a.total_volume)
+        .slice(0, TOP_COUNT)
+        .map((asset) => ({
+            symbol: asset.symbol.toUpperCase(),
+            change: asset.price_change_percentage_24h,
+            volume: asset.total_volume,
+        }))
+
+// The squarify aspect-ratio decisions must see the rendered proportions, so
+// lay out in map units and convert the vertical axis back to percentages.
+const layoutAssets = (rows) => {
+    const height = 100 / MAP_ASPECT
+    return squarify(
+        rows.map((row) => row.volume ** AREA_EXPONENT),
+        100,
+        height
+    ).map((rect) => ({
+        x: rect.x,
+        y: (rect.y / height) * 100,
+        w: rect.w,
+        h: (rect.h / height) * 100,
+    }))
+}
+
+// Absolute value with trimmed trailing zeros; the tile color carries the sign.
+const formatChange = (change) => `${Math.abs(Number(change.toFixed(2)))}%`
+
+const formatUpdatedAt = (date) =>
+    `Today at ${date.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+    })}`
+
+const toneClass = (change) => {
+    const strength = Math.abs(change) >= 3 ? 3 : Math.abs(change) >= 1 ? 2 : 1
+    return styles[`${change < 0 ? "loss" : "gain"}${strength}`]
+}
+
+const HeatmapTile = ({ asset, rect }) => (
+    <div
+        className={cx(styles.tile, toneClass(asset.change))}
+        style={{
+            left: `${rect.x}%`,
+            top: `${rect.y}%`,
+            width: `${rect.w}%`,
+            height: `${rect.h}%`,
+        }}
+    >
+        <FitText fitHeight fill={0.75} minScale={0.35} className={styles.fit}>
+            <span className={styles.labels}>
+                <Text
+                    apple={{ variant: "subheadline2", weight: "semibold" }}
+                    material={{ variant: "subheadline2", weight: "medium" }}
+                >
+                    {asset.symbol}
+                </Text>
+                {rect.h >= MIN_CHANGE_HEIGHT && rect.w >= MIN_CHANGE_WIDTH && (
+                    <Text
+                        apple={{ variant: "subheadline2" }}
+                        material={{ variant: "subheadline2" }}
+                    >
+                        {/* autoSize animates the wrapper width, which
+                            fights FitText's ResizeObserver-driven scale
+                            (fonts visibly jump on mount) — size statically */}
+                        <Calligraph
+                            variant="number"
+                            animation="smooth"
+                            autoSize={false}
+                        >
+                            {formatChange(asset.change)}
+                        </Calligraph>
+                    </Text>
+                )}
+            </span>
+        </FitText>
+    </div>
+)
+
+HeatmapTile.propTypes = {
+    asset: PropTypes.shape({
+        symbol: PropTypes.string.isRequired,
+        change: PropTypes.number.isRequired,
+        volume: PropTypes.number.isRequired,
+    }).isRequired,
+    rect: PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number,
+        w: PropTypes.number,
+        h: PropTypes.number,
+    }).isRequired,
+}
+
+const AssetHeatmap = () => {
+    const { assets, updatedAt, error } = useAssets()
+    const loading = !assets && !error
+
+    const rows = assets ? selectHeatmapAssets(assets) : []
+    const rects = layoutAssets(rows)
+
+    return (
+        <section className={styles.root}>
+            <SectionHeader title="Market heatmap" />
+            <Skeleton active={loading}>
+                <div className={cx(styles.map, !assets && styles.pending)}>
+                    <div className={styles.tiles}>
+                        {rows.map((asset, index) => (
+                            <HeatmapTile
+                                key={asset.symbol}
+                                asset={asset}
+                                rect={rects[index]}
+                            />
+                        ))}
+                    </div>
+                </div>
+                <SectionHeader
+                    type="Footer"
+                    title={
+                        updatedAt ? formatUpdatedAt(updatedAt) : "Today at 00:00"
+                    }
+                />
+            </Skeleton>
+        </section>
+    )
+}
+
+export default AssetHeatmap

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/index.js
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types"
-import { Calligraph } from "calligraph"
 
 import Text from "../../../../../components/Text"
-import FitText from "../../../../../components/FitText"
 import SectionHeader from "../../../../../components/SectionHeader"
 import Skeleton from "../../../../../components/Skeleton"
 
@@ -17,24 +15,48 @@ const cx = (...classes) => classes.filter(Boolean).join(" ")
 const MAP_ASPECT = 1074 / 743
 const TOP_COUNT = 30
 
-// Area compression exponent. BTC and ETH out-trade the tail by ~500x and
-// would swallow the map raw; 0.5 still hands them a third of it, while 0.3
-// flattens the hierarchy into near-equal tiles. 0.4 keeps the dominance
-// readable without crushing the tail.
+// Volume^0.4 area compression: BTC/ETH out-trade the tail ~500x and would
+// swallow the map raw; 0.4 keeps the dominance readable.
 const AREA_EXPONENT = 0.4
 
-// Tiles shorter or narrower than these fractions of the map drop the
-// percent line: the ticker alone gets the room and stays legible.
+// Tiles below these map fractions drop the percent line.
 const MIN_CHANGE_HEIGHT = 13
 const MIN_CHANGE_WIDTH = 9
 
-// Pegged assets sit at ~0% by construction, yet dominate turnover (USDT is
-// the single biggest volume), so they would fill the map with meaningless
-// near-flat tiles — same reasoning as excluding money-market funds from a
-// stock heatmap. The screener tags them, no hand-made ticker list needed.
+// FitText stand-in: tile geometry is known before paint, so the font size
+// is a pure function of the rect (in cqw units; height converts through
+// MAP_ASPECT) — no ResizeObserver, no measure-then-scale pass. sqrt(area)
+// shrinks the tail progressively, the width/height terms are hard bounds
+// against clipping, and the stylesheet caps the result at the ramp size.
+const AREA_K = 0.2
+const FILL_W = 0.7
+const FILL_H = 0.65
+const LINE_EM = 1.1 // pinned in the stylesheet
+const GAP_EM = 0.2 // the 2px labels gap, at typical tile type size
+const CHANGE_SCALE = 0.85 // percent line, relative to the ticker (see SCSS)
+
+// Canvas-measured glyph widths in em, cached per unique label — exact with
+// zero layout involvement. 600 covers both skins: material's medium only
+// renders narrower.
+const measureCtx = document.createElement("canvas").getContext("2d")
+const emWidths = new Map()
+const labelEm = (text, weight) => {
+    const key = `${weight} ${text}`
+    let em = emWidths.get(key)
+    if (em === undefined) {
+        measureCtx.font = `${weight} 100px system-ui, -apple-system, sans-serif`
+        em = measureCtx.measureText(text).width / 100
+        emWidths.set(key, em)
+    }
+    return em
+}
+
+// Stables sit at ~0% yet dominate turnover (USDT is the biggest volume) —
+// meaningless near-flat tiles; the screener already tags them.
 const isStablecoin = (asset) => asset.categories.includes("stablecoins")
 
-// useAssets rows -> heatmap rows, largest first.
+// Largest first; `change` is quantized to display precision so sub-0.01%
+// websocket jitter cannot invalidate tiles whose label and tone are fixed.
 const selectHeatmapAssets = (assets) =>
     assets
         .filter(
@@ -47,12 +69,12 @@ const selectHeatmapAssets = (assets) =>
         .slice(0, TOP_COUNT)
         .map((asset) => ({
             symbol: asset.symbol.toUpperCase(),
-            change: asset.price_change_percentage_24h,
+            change: Number(asset.price_change_percentage_24h.toFixed(2)),
             volume: asset.total_volume,
         }))
 
-// The squarify aspect-ratio decisions must see the rendered proportions, so
-// lay out in map units and convert the vertical axis back to percentages.
+// Squarify must see the rendered proportions: lay out in map units, then
+// convert the vertical axis back to percentages.
 const layoutAssets = (rows) => {
     const height = 100 / MAP_ASPECT
     return squarify(
@@ -81,58 +103,66 @@ const toneClass = (change) => {
     return styles[`${change < 0 ? "loss" : "gain"}${strength}`]
 }
 
-const HeatmapTile = ({ asset, rect }) => (
-    <div
-        className={cx(styles.tile, toneClass(asset.change))}
-        style={{
-            left: `${rect.x}%`,
-            top: `${rect.y}%`,
-            width: `${rect.w}%`,
-            height: `${rect.h}%`,
-        }}
-    >
-        <FitText fitHeight fill={0.75} minScale={0.35} className={styles.fit}>
+// Scalar props: the store publishes a fresh snapshot every flush, so object
+// props would defeat the React Compiler cache — with scalars only tiles
+// whose change actually moved re-render.
+const HeatmapTile = ({ symbol, change, x, y, w, h }) => {
+    const showChange = h >= MIN_CHANGE_HEIGHT && w >= MIN_CHANGE_WIDTH
+    const label = formatChange(change)
+    const hCq = h / MAP_ASPECT // height % -> cqw units
+    const widestEm = Math.max(
+        labelEm(symbol, 600),
+        showChange ? labelEm(label, 400) * CHANGE_SCALE : 0
+    )
+    const linesEm = showChange
+        ? LINE_EM * (1 + CHANGE_SCALE) + GAP_EM
+        : LINE_EM
+    const fit = Math.min(
+        AREA_K * Math.sqrt(w * hCq),
+        (FILL_W * w) / widestEm,
+        (FILL_H * hCq) / linesEm
+    )
+
+    return (
+        <div
+            className={cx(styles.tile, toneClass(change))}
+            style={{
+                left: `${x}%`,
+                top: `${y}%`,
+                width: `${w}%`,
+                height: `${h}%`,
+                "--fit": `${fit.toFixed(3)}cqw`,
+            }}
+        >
             <span className={styles.labels}>
                 <Text
                     apple={{ variant: "subheadline2", weight: "semibold" }}
                     material={{ variant: "subheadline2", weight: "medium" }}
                 >
-                    {asset.symbol}
+                    {symbol}
                 </Text>
-                {rect.h >= MIN_CHANGE_HEIGHT && rect.w >= MIN_CHANGE_WIDTH && (
-                    <Text
-                        apple={{ variant: "subheadline2" }}
-                        material={{ variant: "subheadline2" }}
-                    >
-                        {/* autoSize animates the wrapper width, which
-                            fights FitText's ResizeObserver-driven scale
-                            (fonts visibly jump on mount) — size statically */}
-                        <Calligraph
-                            variant="number"
-                            animation="smooth"
-                            autoSize={false}
+                {showChange && (
+                    <span className={styles.change}>
+                        <Text
+                            apple={{ variant: "subheadline2" }}
+                            material={{ variant: "subheadline2" }}
                         >
-                            {formatChange(asset.change)}
-                        </Calligraph>
-                    </Text>
+                            {label}
+                        </Text>
+                    </span>
                 )}
             </span>
-        </FitText>
-    </div>
-)
+        </div>
+    )
+}
 
 HeatmapTile.propTypes = {
-    asset: PropTypes.shape({
-        symbol: PropTypes.string.isRequired,
-        change: PropTypes.number.isRequired,
-        volume: PropTypes.number.isRequired,
-    }).isRequired,
-    rect: PropTypes.shape({
-        x: PropTypes.number,
-        y: PropTypes.number,
-        w: PropTypes.number,
-        h: PropTypes.number,
-    }).isRequired,
+    symbol: PropTypes.string.isRequired,
+    change: PropTypes.number.isRequired,
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    w: PropTypes.number.isRequired,
+    h: PropTypes.number.isRequired,
 }
 
 const AssetHeatmap = () => {
@@ -151,8 +181,12 @@ const AssetHeatmap = () => {
                         {rows.map((asset, index) => (
                             <HeatmapTile
                                 key={asset.symbol}
-                                asset={asset}
-                                rect={rects[index]}
+                                symbol={asset.symbol}
+                                change={asset.change}
+                                x={rects[index].x}
+                                y={rects[index].y}
+                                w={rects[index].w}
+                                h={rects[index].h}
                             />
                         ))}
                     </div>

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/treemap.js
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/treemap.js
@@ -1,0 +1,62 @@
+// Squarified treemap layout (Bruls, Huizing, van Wijk). Each strip is laid
+// along the shorter side of the remaining rectangle, and items join the
+// current strip while that improves the worst aspect ratio, so tiles stay
+// close to square. Feed weights sorted descending for the canonical
+// largest-first arrangement. Returns rects ({ x, y, w, h }) in the same
+// units and order as the input.
+const worstRatio = (row, side) => {
+    const sum = row.reduce((acc, area) => acc + area, 0)
+    const max = Math.max(...row)
+    const min = Math.min(...row)
+    return Math.max(
+        (side * side * max) / (sum * sum),
+        (sum * sum) / (side * side * min)
+    )
+}
+
+export const squarify = (weights, width, height) => {
+    const total = weights.reduce((acc, weight) => acc + weight, 0)
+    const scale = (width * height) / total
+    const rects = []
+    const rect = { x: 0, y: 0, w: width, h: height }
+    let row = []
+
+    const layoutRow = () => {
+        const sum = row.reduce((acc, area) => acc + area, 0)
+        if (rect.w >= rect.h) {
+            const stripW = sum / rect.h
+            let y = rect.y
+            for (const area of row) {
+                rects.push({ x: rect.x, y, w: stripW, h: area / stripW })
+                y += area / stripW
+            }
+            rect.x += stripW
+            rect.w -= stripW
+        } else {
+            const stripH = sum / rect.w
+            let x = rect.x
+            for (const area of row) {
+                rects.push({ x, y: rect.y, w: area / stripH, h: stripH })
+                x += area / stripH
+            }
+            rect.y += stripH
+            rect.h -= stripH
+        }
+        row = []
+    }
+
+    for (const weight of weights) {
+        const area = weight * scale
+        const side = Math.min(rect.w, rect.h)
+        if (
+            row.length &&
+            worstRatio([...row, area], side) > worstRatio(row, side)
+        ) {
+            layoutRow()
+        }
+        row.push(area)
+    }
+    if (row.length) layoutRow()
+
+    return rects
+}

--- a/src/pages/prototypes/Trading/components/AssetHeatmap/treemap.js
+++ b/src/pages/prototypes/Trading/components/AssetHeatmap/treemap.js
@@ -1,9 +1,6 @@
-// Squarified treemap layout (Bruls, Huizing, van Wijk). Each strip is laid
-// along the shorter side of the remaining rectangle, and items join the
-// current strip while that improves the worst aspect ratio, so tiles stay
-// close to square. Feed weights sorted descending for the canonical
-// largest-first arrangement. Returns rects ({ x, y, w, h }) in the same
-// units and order as the input.
+// Squarified treemap (Bruls, Huizing, van Wijk): items join the current
+// strip while that improves the worst aspect ratio. Feed weights sorted
+// descending; returns rects ({ x, y, w, h }) in input units and order.
 const worstRatio = (row, side) => {
     const sum = row.reduce((acc, area) => acc + area, 0)
     const max = Math.max(...row)

--- a/src/pages/prototypes/Trading/components/AssetList/AssetList.module.scss
+++ b/src/pages/prototypes/Trading/components/AssetList/AssetList.module.scss
@@ -1,0 +1,37 @@
+// The sizer holds the full list height; only the on-screen slice mounts,
+// each row translated to its slot.
+.sizer {
+    position: relative;
+    align-self: stretch;
+}
+
+.row {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+}
+
+// Delta color rides the wrapper (Text [variant] inherits), per convention.
+.delta {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 2px;
+
+    &.up {
+        color: var(--text-confirm-color);
+    }
+
+    &.down {
+        color: var(--tg-theme-destructive-text-color);
+    }
+
+    // Yield to the skeleton's transparent-text redaction. Must be color,
+    // not opacity: ancestor opacity doesn't dim Calligraph in WebKit.
+    :global([data-skeleton]) & {
+        &.up,
+        &.down {
+            color: transparent;
+        }
+    }
+}

--- a/src/pages/prototypes/Trading/components/AssetList/index.js
+++ b/src/pages/prototypes/Trading/components/AssetList/index.js
@@ -1,0 +1,174 @@
+import { useLayoutEffect, useRef, useState } from "react"
+import PropTypes from "prop-types"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { Calligraph } from "calligraph"
+
+import { formatPercentage, formatPrice } from "../../../../../utils/number"
+
+import SectionList from "../../../../../components/SectionList"
+import Cell from "../../../../../components/Cells"
+import ImageAvatar from "../../../../../components/ImageAvatar"
+import Skeleton from "../../../../../components/Skeleton"
+
+import useAssets from "../../../../../hooks/useAssets"
+
+import * as styles from "./AssetList.module.scss"
+
+// Loading rows; the varied mock lengths give the skeleton a realistic
+// rhythm instead of identical bars.
+const PLACEHOLDER_ASSETS = [
+    { name: "Bitcoin", symbol: "btc", current_price: 64120, pct: 2.4 },
+    { name: "Ethereum", symbol: "eth", current_price: 3180, pct: -1.1 },
+    { name: "Toncoin", symbol: "ton", current_price: 5.42, pct: 0.8 },
+    { name: "Solana", symbol: "sol", current_price: 142.6, pct: 3.9 },
+    { name: "Notcoin", symbol: "not", current_price: 0.0091, pct: -2.2 },
+    { name: "Tether", symbol: "usdt", current_price: 1.0, pct: 0.4 },
+    { name: "Dogecoin", symbol: "doge", current_price: 0.121, pct: 1.5 },
+    { name: "Polygon", symbol: "matic", current_price: 0.72, pct: -0.6 },
+]
+
+// The estimate seeds the scrollbar until measureElement reports real row
+// heights (they differ per platform ramp).
+const ESTIMATED_ROW = 64
+const OVERSCAN = 5
+
+// Live rows carry a catalog-resolved `image`; the XTVC guess only backs
+// the local placeholders.
+const assetIcon = (asset) =>
+    asset.image ??
+    `https://s3-symbol-logo.tradingview.com/crypto/XTVC${asset.symbol?.toUpperCase()}--big.svg`
+
+// The arrow sits outside the odometer so a sign flip swaps it instantly
+// instead of morphing through the digit animation.
+const Delta = ({ value }) => {
+    const up = value >= 0
+    return (
+        <span className={`${styles.delta} ${up ? styles.up : styles.down}`}>
+            {up ? "↑" : "↓"}
+            <Calligraph variant="number" animation="smooth">
+                {formatPercentage(Math.abs(value))}
+            </Calligraph>
+        </span>
+    )
+}
+
+Delta.propTypes = {
+    value: PropTypes.number.isRequired,
+}
+
+const AssetRow = ({ asset }) => (
+    <Cell
+        start={<ImageAvatar src={assetIcon(asset)} />}
+        end={
+            <Cell.Text
+                title={
+                    <>
+                        $
+                        <Calligraph variant="number" animation="smooth">
+                            {formatPrice(asset.current_price)}
+                        </Calligraph>
+                    </>
+                }
+                description={
+                    <Delta
+                        value={asset.price_change_percentage_24h ?? asset.pct}
+                    />
+                }
+            />
+        }
+    >
+        <Cell.Text
+            title={asset.name}
+            description={asset.symbol?.toUpperCase()}
+            bold
+        />
+    </Cell>
+)
+
+AssetRow.propTypes = {
+    asset: PropTypes.shape({
+        name: PropTypes.string,
+        symbol: PropTypes.string,
+        image: PropTypes.string,
+        current_price: PropTypes.number,
+        price_change_percentage_24h: PropTypes.number,
+        pct: PropTypes.number,
+    }).isRequired,
+}
+
+// The page scroller lives in PageTransition, a few ancestors up.
+const findScrollParent = (node) => {
+    for (let el = node.parentElement; el; el = el.parentElement) {
+        if (/auto|scroll/.test(getComputedStyle(el).overflowY)) return el
+    }
+    return null
+}
+
+const AssetList = () => {
+    const { assets, error } = useAssets()
+    const loading = !assets && !error
+    const rows = assets ?? PLACEHOLDER_ASSETS
+
+    const listRef = useRef(null)
+    const [scrollEl, setScrollEl] = useState(null)
+    const [listOffset, setListOffset] = useState(0)
+
+    useLayoutEffect(() => {
+        const list = listRef.current
+        const scroller = findScrollParent(list)
+        setScrollEl(scroller)
+        if (!scroller) return undefined
+        // Rect-based: the offsetParent chain dead-ends at whichever
+        // ancestor happens to carry a transform. Re-measured on resize —
+        // the aspect-ratio heatmap above moves the list start.
+        const measure = () =>
+            setListOffset(
+                list.getBoundingClientRect().top -
+                    scroller.getBoundingClientRect().top +
+                    scroller.scrollTop
+            )
+        measure()
+        window.addEventListener("resize", measure)
+        return () => window.removeEventListener("resize", measure)
+    }, [])
+
+    // The compiler skips this component either way; scroll re-renders are the point.
+    // eslint-disable-next-line react-hooks/incompatible-library
+    const virtualizer = useVirtualizer({
+        count: rows.length,
+        getScrollElement: () => scrollEl,
+        estimateSize: () => ESTIMATED_ROW,
+        overscan: OVERSCAN,
+        scrollMargin: listOffset,
+    })
+
+    return (
+        <SectionList.Item header="Today's lists">
+            <Skeleton active={loading}>
+                <div
+                    ref={listRef}
+                    className={styles.sizer}
+                    style={{ height: virtualizer.getTotalSize() }}
+                >
+                    {/* Index keys: placeholder and live rows share identity,
+                        so bars reveal in place when data lands. */}
+                    {virtualizer.getVirtualItems().map((item) => (
+                        <div
+                            key={item.key}
+                            ref={virtualizer.measureElement}
+                            data-index={item.index}
+                            className={styles.row}
+                            style={{
+                                transform: `translateY(${item.start - listOffset}px)`,
+                            }}
+                        >
+                            <AssetRow asset={rows[item.index]} />
+                        </div>
+                    ))}
+                </div>
+            </Skeleton>
+        </SectionList.Item>
+    )
+}
+
+export default AssetList

--- a/src/pages/prototypes/Trading/components/AssetList/index.js
+++ b/src/pages/prototypes/Trading/components/AssetList/index.js
@@ -45,7 +45,7 @@ const Delta = ({ value }) => {
     return (
         <span className={`${styles.delta} ${up ? styles.up : styles.down}`}>
             {up ? "↑" : "↓"}
-            <Calligraph variant="number" animation="smooth">
+            <Calligraph variant="number" animation="smooth" autoSize={false}>
                 {formatPercentage(Math.abs(value))}
             </Calligraph>
         </span>
@@ -56,6 +56,11 @@ Delta.propTypes = {
     value: PropTypes.number.isRequired,
 }
 
+// Odometers are keyed by symbol: rows themselves are keyed by index (the
+// skeleton reveals in place when data lands), so on a rank reorder the same
+// row hosts another coin — remount the digits instead of morphing one
+// coin's price into another's. autoSize is off: it animates the wrapper
+// width (layout) on every tick that changes digit count.
 const AssetRow = ({ asset }) => (
     <Cell
         start={<ImageAvatar src={assetIcon(asset)} />}
@@ -64,13 +69,19 @@ const AssetRow = ({ asset }) => (
                 title={
                     <>
                         $
-                        <Calligraph variant="number" animation="smooth">
+                        <Calligraph
+                            key={asset.symbol}
+                            variant="number"
+                            animation="smooth"
+                            autoSize={false}
+                        >
                             {formatPrice(asset.current_price)}
                         </Calligraph>
                     </>
                 }
                 description={
                     <Delta
+                        key={asset.symbol}
                         value={asset.price_change_percentage_24h ?? asset.pct}
                     />
                 }

--- a/src/pages/prototypes/Trading/index.js
+++ b/src/pages/prototypes/Trading/index.js
@@ -1,64 +1,16 @@
-import PropTypes from "prop-types"
-import { Calligraph } from "calligraph"
-
-import { formatPercentage, formatPrice } from "../../../utils/number"
-
 import Text from "../../../components/Text"
 import Page from "../../../components/Page"
 import SectionList from "../../../components/SectionList"
-import Cell from "../../../components/Cells"
-import ImageAvatar from "../../../components/ImageAvatar"
-import Skeleton from "../../../components/Skeleton"
 
 import AssetHeatmap from "./components/AssetHeatmap"
+import AssetList from "./components/AssetList"
 
 import useAssets from "../../../hooks/useAssets"
 
 import * as styles from "./Trading.module.scss"
 
-// Shown while loading. Same shape as the API response so the row markup is
-// uniform; the varied mock lengths give the skeleton a realistic rhythm
-// instead of identical bars.
-const PLACEHOLDER_ASSETS = [
-    { name: "Bitcoin", symbol: "btc", current_price: 64120, pct: 2.4 },
-    { name: "Ethereum", symbol: "eth", current_price: 3180, pct: -1.1 },
-    { name: "Toncoin", symbol: "ton", current_price: 5.42, pct: 0.8 },
-    { name: "Solana", symbol: "sol", current_price: 142.6, pct: 3.9 },
-    { name: "Notcoin", symbol: "not", current_price: 0.0091, pct: -2.2 },
-    { name: "Tether", symbol: "usdt", current_price: 1.0, pct: 0.4 },
-    { name: "Dogecoin", symbol: "doge", current_price: 0.121, pct: 1.5 },
-    { name: "Polygon", symbol: "matic", current_price: 0.72, pct: -0.6 },
-]
-
-// Live rows carry a resolved `image` from the shared catalog, so icons always
-// match the coin. The XTVC guess only backs the local placeholder rows, which
-// predate the live catalog.
-const assetIcon = (asset) =>
-    asset.image ??
-    `https://s3-symbol-logo.tradingview.com/crypto/XTVC${asset.symbol?.toUpperCase()}--big.svg`
-
-// 24h move with a direction arrow instead of a sign, tinted by the app's
-// semantic tokens; the arrow sits outside the odometer so a sign flip swaps
-// it instantly instead of morphing through the digit animation.
-const Delta = ({ value }) => {
-    const up = value >= 0
-    return (
-        <span className={`${styles.delta} ${up ? styles.up : styles.down}`}>
-            {up ? "↑" : "↓"}
-            <Calligraph variant="number" animation="smooth">
-                {formatPercentage(Math.abs(value))}
-            </Calligraph>
-        </span>
-    )
-}
-
-Delta.propTypes = {
-    value: PropTypes.number.isRequired,
-}
-
 function Trading() {
-    const { assets, error } = useAssets()
-    const loading = !assets && !error
+    const { error } = useAssets()
 
     if (error) {
         return (
@@ -70,58 +22,11 @@ function Trading() {
         )
     }
 
-    // Keyed by index (not id) so the placeholder rows and the real rows share
-    // element identity: when data lands, each bar reveals in place instead of
-    // the whole list remounting.
-    const rows = assets ?? PLACEHOLDER_ASSETS
-
     return (
         <Page>
             <SectionList>
                 <AssetHeatmap />
-                <SectionList.Item header="Today's lists">
-                    <Skeleton active={loading}>
-                        {rows.map((asset, index) => (
-                            <Cell
-                                key={index}
-                                start={
-                                    <ImageAvatar src={assetIcon(asset)} />
-                                }
-                                end={
-                                    <Cell.Text
-                                        title={
-                                            <>
-                                                $
-                                                <Calligraph
-                                                    variant="number"
-                                                    animation="smooth"
-                                                >
-                                                    {formatPrice(
-                                                        asset.current_price
-                                                    )}
-                                                </Calligraph>
-                                            </>
-                                        }
-                                        description={
-                                            <Delta
-                                                value={
-                                                    asset.price_change_percentage_24h ??
-                                                    asset.pct
-                                                }
-                                            />
-                                        }
-                                    />
-                                }
-                            >
-                                <Cell.Text
-                                    title={asset.name}
-                                    description={asset.symbol?.toUpperCase()}
-                                    bold
-                                />
-                            </Cell>
-                        ))}
-                    </Skeleton>
-                </SectionList.Item>
+                <AssetList />
             </SectionList>
         </Page>
     )

--- a/src/pages/prototypes/Trading/index.js
+++ b/src/pages/prototypes/Trading/index.js
@@ -1,4 +1,7 @@
-import { formatPercentage } from "../../../utils/number"
+import PropTypes from "prop-types"
+import { Calligraph } from "calligraph"
+
+import { formatPercentage, formatPrice } from "../../../utils/number"
 
 import Text from "../../../components/Text"
 import Page from "../../../components/Page"
@@ -6,6 +9,8 @@ import SectionList from "../../../components/SectionList"
 import Cell from "../../../components/Cells"
 import ImageAvatar from "../../../components/ImageAvatar"
 import Skeleton from "../../../components/Skeleton"
+
+import AssetHeatmap from "./components/AssetHeatmap"
 
 import useAssets from "../../../hooks/useAssets"
 
@@ -15,18 +20,42 @@ import * as styles from "./Trading.module.scss"
 // uniform; the varied mock lengths give the skeleton a realistic rhythm
 // instead of identical bars.
 const PLACEHOLDER_ASSETS = [
-    { name: "Bitcoin", symbol: "btc", current_price: "64,120", pct: 2.4 },
-    { name: "Ethereum", symbol: "eth", current_price: "3,180", pct: -1.1 },
-    { name: "Toncoin", symbol: "ton", current_price: "5.42", pct: 0.8 },
-    { name: "Solana", symbol: "sol", current_price: "142.6", pct: 3.9 },
-    { name: "Notcoin", symbol: "not", current_price: "0.0091", pct: -2.2 },
-    { name: "Tether", symbol: "usdt", current_price: "1.00", pct: 0.4 },
-    { name: "Dogecoin", symbol: "doge", current_price: "0.121", pct: 1.5 },
-    { name: "Polygon", symbol: "matic", current_price: "0.72", pct: -0.6 },
+    { name: "Bitcoin", symbol: "btc", current_price: 64120, pct: 2.4 },
+    { name: "Ethereum", symbol: "eth", current_price: 3180, pct: -1.1 },
+    { name: "Toncoin", symbol: "ton", current_price: 5.42, pct: 0.8 },
+    { name: "Solana", symbol: "sol", current_price: 142.6, pct: 3.9 },
+    { name: "Notcoin", symbol: "not", current_price: 0.0091, pct: -2.2 },
+    { name: "Tether", symbol: "usdt", current_price: 1.0, pct: 0.4 },
+    { name: "Dogecoin", symbol: "doge", current_price: 0.121, pct: 1.5 },
+    { name: "Polygon", symbol: "matic", current_price: 0.72, pct: -0.6 },
 ]
 
-const assetIcon = (symbol) =>
-    `https://s3-symbol-logo.tradingview.com/crypto/XTVC${symbol?.toUpperCase()}--big.svg`
+// TradingView logo by the row's own logoid — the data source and the logo
+// catalog are the same, so icons always match the coin. The XTVC guess only
+// backs the placeholder rows, which predate the live catalog.
+const assetIcon = (asset) =>
+    `https://s3-symbol-logo.tradingview.com/${
+        asset.logoid ?? `crypto/XTVC${asset.symbol?.toUpperCase()}`
+    }--big.svg`
+
+// 24h move with a direction arrow instead of a sign, tinted by the app's
+// semantic tokens; the arrow sits outside the odometer so a sign flip swaps
+// it instantly instead of morphing through the digit animation.
+const Delta = ({ value }) => {
+    const up = value >= 0
+    return (
+        <span className={`${styles.delta} ${up ? styles.up : styles.down}`}>
+            {up ? "↑" : "↓"}
+            <Calligraph variant="number" animation="smooth">
+                {formatPercentage(Math.abs(value))}
+            </Calligraph>
+        </span>
+    )
+}
+
+Delta.propTypes = {
+    value: PropTypes.number.isRequired,
+}
 
 function Trading() {
     const { assets, error } = useAssets()
@@ -50,21 +79,38 @@ function Trading() {
     return (
         <Page>
             <SectionList>
+                <AssetHeatmap />
                 <SectionList.Item header="Today's lists">
                     <Skeleton active={loading}>
                         {rows.map((asset, index) => (
                             <Cell
                                 key={index}
                                 start={
-                                    <ImageAvatar src={assetIcon(asset.symbol)} />
+                                    <ImageAvatar src={assetIcon(asset)} />
                                 }
                                 end={
                                     <Cell.Text
-                                        title={`$${asset.current_price}`}
-                                        description={formatPercentage(
-                                            asset.price_change_percentage_24h ??
-                                                asset.pct
-                                        )}
+                                        title={
+                                            <>
+                                                $
+                                                <Calligraph
+                                                    variant="number"
+                                                    animation="smooth"
+                                                >
+                                                    {formatPrice(
+                                                        asset.current_price
+                                                    )}
+                                                </Calligraph>
+                                            </>
+                                        }
+                                        description={
+                                            <Delta
+                                                value={
+                                                    asset.price_change_percentage_24h ??
+                                                    asset.pct
+                                                }
+                                            />
+                                        }
                                     />
                                 }
                             >

--- a/src/pages/prototypes/Trading/index.js
+++ b/src/pages/prototypes/Trading/index.js
@@ -30,13 +30,12 @@ const PLACEHOLDER_ASSETS = [
     { name: "Polygon", symbol: "matic", current_price: 0.72, pct: -0.6 },
 ]
 
-// TradingView logo by the row's own logoid — the data source and the logo
-// catalog are the same, so icons always match the coin. The XTVC guess only
-// backs the placeholder rows, which predate the live catalog.
+// Live rows carry a resolved `image` from the shared catalog, so icons always
+// match the coin. The XTVC guess only backs the local placeholder rows, which
+// predate the live catalog.
 const assetIcon = (asset) =>
-    `https://s3-symbol-logo.tradingview.com/${
-        asset.logoid ?? `crypto/XTVC${asset.symbol?.toUpperCase()}`
-    }--big.svg`
+    asset.image ??
+    `https://s3-symbol-logo.tradingview.com/crypto/XTVC${asset.symbol?.toUpperCase()}--big.svg`
 
 // 24h move with a direction arrow instead of a sign, tinted by the app's
 // semantic tokens; the arrow sits outside the odometer so a sign flip swaps

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -10,4 +10,15 @@ export function formatPercentage(percentage) {
     return `${percentage?.toFixed(2)}%`
 }
 
+// USD notation: grouped thousands with cents for prices from $1, four
+// significant digits below that so micro-cap prices stay meaningful.
+export function formatPrice(price) {
+    if (typeof price !== "number") return price
+    const options =
+        price >= 1
+            ? { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+            : { maximumSignificantDigits: 4 }
+    return price.toLocaleString("en-US", options)
+}
+
 export const clamp = (value, min, max) => Math.min(Math.max(value, min), max)

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -10,8 +10,7 @@ export function formatPercentage(percentage) {
     return `${percentage?.toFixed(2)}%`
 }
 
-// USD notation: grouped thousands with cents for prices from $1, four
-// significant digits below that so micro-cap prices stay meaningful.
+// Cents from $1, four significant digits below (micro-cap prices).
 export function formatPrice(price) {
     if (typeof price !== "number") return price
     const options =

--- a/src/utils/tradingViewQuotes.js
+++ b/src/utils/tradingViewQuotes.js
@@ -1,7 +1,6 @@
-// Minimal client for TradingView's public quote websocket — the same feed
-// their charts and screener pages use. Messages ride a length-prefixed
-// framing (`~m~<len>~m~<json>`); `~h~N` frames are heartbeats the server
-// expects echoed back verbatim, or it drops the connection.
+// Minimal client for TradingView's public quote websocket. Messages ride a
+// length-prefixed framing (`~m~<len>~m~<json>`); `~h~N` heartbeats must be
+// echoed back verbatim or the server drops the connection.
 const ENDPOINT = "wss://data.tradingview.com/socket.io/websocket?from=screener"
 const RECONNECT_DELAY = 3_000
 
@@ -9,10 +8,9 @@ const FRAME_SPLIT = /~m~\d+~m~/
 
 const wrap = (payload) => `~m~${payload.length}~m~${payload}`
 
-// Opens a quote session for `symbols` (e.g. "CRYPTO:BTCUSD") streaming the
-// given `fields` (e.g. ["lp", "chp"]). `onTick(name, values)` fires per
-// update with only the fields that changed. Reconnects itself until
-// `close()` is called.
+// Streams `fields` (e.g. ["lp", "chp"]) for `symbols` ("CRYPTO:BTCUSD");
+// `onTick(name, values)` carries only the fields that changed. Reconnects
+// itself until `close()`.
 export const openQuoteStream = ({ symbols, fields, onTick }) => {
     let ws = null
     let reconnectTimer = null

--- a/src/utils/tradingViewQuotes.js
+++ b/src/utils/tradingViewQuotes.js
@@ -1,0 +1,70 @@
+// Minimal client for TradingView's public quote websocket — the same feed
+// their charts and screener pages use. Messages ride a length-prefixed
+// framing (`~m~<len>~m~<json>`); `~h~N` frames are heartbeats the server
+// expects echoed back verbatim, or it drops the connection.
+const ENDPOINT = "wss://data.tradingview.com/socket.io/websocket?from=screener"
+const RECONNECT_DELAY = 3_000
+
+const FRAME_SPLIT = /~m~\d+~m~/
+
+const wrap = (payload) => `~m~${payload.length}~m~${payload}`
+
+// Opens a quote session for `symbols` (e.g. "CRYPTO:BTCUSD") streaming the
+// given `fields` (e.g. ["lp", "chp"]). `onTick(name, values)` fires per
+// update with only the fields that changed. Reconnects itself until
+// `close()` is called.
+export const openQuoteStream = ({ symbols, fields, onTick }) => {
+    let ws = null
+    let reconnectTimer = null
+    let closed = false
+
+    const connect = () => {
+        ws = new WebSocket(ENDPOINT)
+        const send = (m, p) => ws.send(wrap(JSON.stringify({ m, p })))
+        const session = `qs_${Math.random().toString(36).slice(2, 12)}`
+
+        ws.onopen = () => {
+            send("set_auth_token", ["unauthorized_user_token"])
+            send("quote_create_session", [session])
+            send("quote_set_fields", [session, ...fields])
+            send("quote_add_symbols", [session, ...symbols])
+        }
+
+        ws.onmessage = (event) => {
+            for (const part of String(event.data).split(FRAME_SPLIT)) {
+                if (!part) continue
+                if (part.startsWith("~h~")) {
+                    ws.send(wrap(part))
+                    continue
+                }
+                let message
+                try {
+                    message = JSON.parse(part)
+                } catch {
+                    continue // session banner and other non-JSON frames
+                }
+                if (message.m !== "qsd") continue
+                const quote = message.p?.[1]
+                if (quote?.s === "ok" && quote.v) onTick(quote.n, quote.v)
+            }
+        }
+
+        ws.onclose = () => {
+            if (closed) return
+            reconnectTimer = setTimeout(connect, RECONNECT_DELAY)
+        }
+
+        // onclose fires afterwards and schedules the reconnect
+        ws.onerror = () => ws.close()
+    }
+
+    connect()
+
+    return {
+        close: () => {
+            closed = true
+            clearTimeout(reconnectTimer)
+            ws?.close()
+        },
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.14.5":
+  version: 3.14.5
+  resolution: "@tanstack/react-virtual@npm:3.14.5"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/f3dd2da5e5e0a94756e47f11fa76bfe0485e845da72b8022a4a593e2906aa60b827a5f0d7b6063092c76874fed8ddc69bcbf759298733ced24a66a82e8d58f21
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.3":
+  version: 3.17.3
+  resolution: "@tanstack/virtual-core@npm:3.17.3"
+  checksum: 10c0/e6199a0c25d1780e62f57c9f72432342e2cabd5b1197cf66b0f2250c9c0bbecbd0c53e7bb639804c4c7931f9cfa57efa80f6a64fefe6614bf14871f682c17aa3
+  languageName: node
+  linkType: hard
+
 "@types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -5768,6 +5787,7 @@ __metadata:
     "@lisse/react": "npm:^0.4.0"
     "@relative-ci/agent": "npm:^4.3.1"
     "@resvg/resvg-js": "npm:^2.6.2"
+    "@tanstack/react-virtual": "npm:^3.14.5"
     "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:5"


### PR DESCRIPTION
## Summary

Adds a **Market heatmap** section to the Trade tab and moves the whole tab onto live TradingView data.

### Heatmap (`Trading/components/AssetHeatmap`)
- Squarified treemap of the top 30 coins by 24h turnover; tile area tracks `volume^0.4` (raw volumes span ~500x and crush the tail; sqrt still hands BTC+ETH a third of the map)
- Diverging tone scale derived from the app's semantic tokens via OKLCH relative colors: hue follows whatever the active Telegram theme supplies, lightness/chroma pinned per strength tier (1% / 3% thresholds), hex fallbacks for engines without relative color syntax
- Standard section chrome: `SectionHeader` title, footer with the snapshot time, transparent background; the map clips its own rounded corners so edge tiles meet the section radius while inner tiles stay flat 8px
- Labels fit via `FitText` (new opt-in `fitHeight` and `fill` props, backwards compatible); narrow/short tiles drop the percent line; percents tick through `Calligraph` odometers (`autoSize` off — its width spring fights ResizeObserver-driven fitters)
- Stablecoins excluded by the screener's category tag (pegged assets dominate turnover but sit at ~0%)

### Data feed (`useAssets` + `utils/tradingViewQuotes`)
- Replaced the CoinGecko proxy with TradingView's coin screener: one open-CORS request carries prices, deltas, volumes, categories and logo ids, so list icons always match the coin (logo URLs can't be guessed from tickers: XTVCHYPE is not Hyperliquid). POST is sent without a Content-Type header on purpose — the scanner's preflight rejects it, a bare text/plain POST skips preflight entirely
- Live prices stream over TradingView's public quote websocket (session/heartbeat protocol client in `utils/tradingViewQuotes.js`); ticks buffer and flush into the store at most once per second, the scanner poll (60s) only maintains the universe
- Store is a `useSyncExternalStore` module singleton: one socket and one poll shared by all subscribers, teardown when the last one leaves, stale snapshot served through network failures

### Today's lists polish
- Prices formatted (`formatPrice`: grouped thousands, 4 significant digits under $1) and animated with Calligraph
- Deltas show direction arrows instead of signs, tinted by the confirm/destructive theme tokens

Verified with `yarn lint` and `yarn build`; quote protocol and scanner queries exercised end-to-end from Node during development.

Generated with [Claude Code](https://claude.com/claude-code)