### PR TITLE
Добавить компактный iOS-таббар, который уменьшается при прокрутке

### DIFF
--- a/src/components/TabBar/TabBar.module.scss
+++ b/src/components/TabBar/TabBar.module.scss
@@ -3,25 +3,13 @@
     position: relative;
     align-items: flex-start;
     align-self: stretch;
-    box-shadow: 0 -0.33px 0 0 var(--separator-non-opaque);
-    padding-bottom: env(safe-area-inset-bottom);
 
     :global(body.apple) & {
         position: absolute;
         left: 21px;
         right: 21px;
         bottom: var(--bottom-clearance, 21px);
-        border-radius: 100px;
-        padding: 4px;
         margin: 0;
-        background: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
-        backdrop-filter: saturate(300%) blur(8px);
-        box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
-
-        @supports (-apple-visual-effect: -apple-system-glass-material) {
-            -apple-visual-effect: -apple-system-glass-material;
-            backdrop-filter: none;
-        }
     }
 
     :global(body.material) & {
@@ -29,45 +17,69 @@
         left: 16px;
         right: 16px;
         bottom: var(--bottom-clearance, 16px);
-        border-radius: 100px;
-        padding: 4px;
         width: calc(100% - 32px);
-        background: rgb(from var(--tg-theme-section-bg-color) r g b / 84%);
-        backdrop-filter: blur(30px) saturate(10);
-        box-shadow:
-            0 1px 2px 0 rgb(0 0 0 / 8%),
-            0 2px 16px 1px rgb(0 0 0 / 10%);
     }
 
-    &::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        pointer-events: none;
-        background: rgb(from var(--quaternary-fill-background) r g b / 4%);
-        z-index: 0;
-    }
+    .surface {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        width: 100%;
+        padding: 4px;
+        border-radius: 100px;
+        transform: scale(var(--tabbar-scroll-scale, 1));
+        transform-origin: center bottom;
 
-    // Apple already gets GlassBorder; a glass surface carries exactly one
-    // border, so the blended hairlines exist only where GlassBorder doesn't.
-    :global(body.material) &::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        pointer-events: none;
-        box-shadow:
-            inset 0 1px 0 0 #fff,
-            inset 0 -0.5px 0 0 #fff;
-        mix-blend-mode: soft-light;
-        z-index: 2;
+        :global(body.apple) & {
+            background: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
+            backdrop-filter: saturate(300%) blur(8px);
+            box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+
+            @supports (-apple-visual-effect: -apple-system-glass-material) {
+                -apple-visual-effect: -apple-system-glass-material;
+                backdrop-filter: none;
+            }
+        }
+
+        :global(body.material) & {
+            background: rgb(from var(--tg-theme-section-bg-color) r g b / 84%);
+            backdrop-filter: blur(30px) saturate(10);
+            box-shadow:
+                0 1px 2px 0 rgb(0 0 0 / 8%),
+                0 2px 16px 1px rgb(0 0 0 / 10%);
+        }
+
+        &::before {
+            position: absolute;
+            inset: 0;
+            z-index: 0;
+            border-radius: inherit;
+            background: rgb(from var(--quaternary-fill-background) r g b / 4%);
+            pointer-events: none;
+            content: "";
+        }
+
+        // Apple already gets GlassBorder; a glass surface carries exactly one
+        // border, so the hairlines exist only where GlassBorder doesn't.
+        :global(body.material) &::after {
+            position: absolute;
+            inset: 0;
+            z-index: 2;
+            border-radius: inherit;
+            box-shadow:
+                inset 0 1px 0 0 #fff,
+                inset 0 -0.5px 0 0 #fff;
+            mix-blend-mode: soft-light;
+            pointer-events: none;
+            content: "";
+        }
     }
 
     .content {
         display: flex;
         position: relative;
         width: 100%;
+        margin-inline: auto;
         z-index: 1;
     }
 
@@ -80,12 +92,20 @@
         --overlay-padding-y: 21px;
 
         position: absolute;
-        inset: 0;
-        width: calc(100% + var(--overlay-padding-x) * 2);
+        top: 0;
+        left: 50%;
+        width: 100vw;
         height: calc(64px + var(--overlay-padding-y) * 2);
         z-index: 0;
-        margin: calc(var(--overlay-padding-y) * -1)
-            calc(var(--overlay-padding-x) * -1);
+        margin-top: calc(var(--overlay-padding-y) * -1);
+        pointer-events: none;
+        transform: translateX(-50%);
+    }
+
+    .gradientCutout {
+        transform: scale(var(--tabbar-scroll-scale, 1));
+        transform-box: fill-box;
+        transform-origin: center bottom;
     }
 
     .activeIndicator {
@@ -114,6 +134,7 @@
 
     .clipPathContainer {
         position: absolute;
+        left: 50%;
         display: flex;
         background-color: var(--tertiary-fill-background);
         width: calc(100% - 8px);
@@ -121,7 +142,7 @@
         will-change: clip-path;
         z-index: 10;
         overflow: hidden;
-        transform: translateZ(0);
+        transform: translateX(-50%) translateZ(0);
         isolation: isolate;
         backface-visibility: hidden;
 

--- a/src/components/TabBar/TabBar.module.scss
+++ b/src/components/TabBar/TabBar.module.scss
@@ -92,13 +92,14 @@
         --overlay-padding-y: 21px;
 
         position: absolute;
-        inset: 0;
-        width: calc(100% + var(--overlay-padding-x) * 2);
+        top: 0;
+        left: 50%;
+        width: 100vw;
         height: calc(100% + var(--overlay-padding-y) * 2);
         z-index: 0;
-        margin: calc(var(--overlay-padding-y) * -1)
-            calc(var(--overlay-padding-x) * -1);
+        margin-top: calc(var(--overlay-padding-y) * -1);
         pointer-events: none;
+        transform: translateX(-50%);
     }
 
     .gradientCutout {

--- a/src/components/TabBar/TabBar.module.scss
+++ b/src/components/TabBar/TabBar.module.scss
@@ -92,14 +92,13 @@
         --overlay-padding-y: 21px;
 
         position: absolute;
-        top: 0;
-        left: 50%;
-        width: 100vw;
-        height: calc(64px + var(--overlay-padding-y) * 2);
+        inset: 0;
+        width: calc(100% + var(--overlay-padding-x) * 2);
+        height: calc(100% + var(--overlay-padding-y) * 2);
         z-index: 0;
-        margin-top: calc(var(--overlay-padding-y) * -1);
+        margin: calc(var(--overlay-padding-y) * -1)
+            calc(var(--overlay-padding-x) * -1);
         pointer-events: none;
-        transform: translateX(-50%);
     }
 
     .gradientCutout {

--- a/src/components/TabBar/TabBar.showcase.js
+++ b/src/components/TabBar/TabBar.showcase.js
@@ -21,6 +21,8 @@ const allTabs = [
 ]
 
 const tabCounts = ["2", "3", "4"]
+const displayModes = ["Default", "Compact"]
+const demoRows = Array.from({ length: 12 }, (_, index) => `Scroll row ${index + 1}`)
 
 const wrapperStyle = {
     position: "fixed",
@@ -33,8 +35,10 @@ const wrapperStyle = {
 
 const TabBarShowcase = () => {
     const [pickerIndex, setPickerIndex] = useState(0)
+    const [displayModeIndex, setDisplayModeIndex] = useState(0)
     const count = parseInt(tabCounts[pickerIndex], 10)
     const tabs = allTabs.slice(0, count)
+    const compact = displayModes[displayModeIndex] === "Compact"
 
     return (
         <>
@@ -56,10 +60,36 @@ const TabBarShowcase = () => {
                             onPickerIndex={setPickerIndex}
                         />
                     </SectionList.Item>
+                    <SectionList.Item>
+                        <Cell
+                            end={
+                                <Cell.Part type="Picker">
+                                    {displayModes[displayModeIndex]}
+                                </Cell.Part>
+                            }
+                        >
+                            <Cell.Text title="Tab bar mode" />
+                        </Cell>
+                        <Picker
+                            items={displayModes}
+                            onPickerIndex={setDisplayModeIndex}
+                        />
+                    </SectionList.Item>
+                    <SectionList.Item>
+                        {demoRows.map((title) => (
+                            <Cell key={title}>
+                                <Cell.Text title={title} />
+                            </Cell>
+                        ))}
+                    </SectionList.Item>
                 </SectionList>
                 <div style={wrapperStyle}>
                     <div style={{ pointerEvents: "auto" }}>
-                        <TabBar tabs={tabs} />
+                        <TabBar
+                            tabs={tabs}
+                            variant={compact ? "compact" : "default"}
+                            collapseOnScroll={compact}
+                        />
                     </div>
                 </div>
             </Page>

--- a/src/components/TabBar/components/GradientMask/index.js
+++ b/src/components/TabBar/components/GradientMask/index.js
@@ -63,6 +63,7 @@ function GradientMask({
                         fill="white"
                     />
                     <rect
+                        className={styles.gradientCutout}
                         x={left}
                         y={top}
                         width={innerWidth}

--- a/src/components/TabBar/components/Tab/Tab.module.scss
+++ b/src/components/TabBar/components/Tab/Tab.module.scss
@@ -75,6 +75,10 @@
         padding: 6px 0 8px;
     }
 
+    :global(body.material) & {
+        padding: 6px 0;
+    }
+
     svg,
     path,
     .icon {

--- a/src/components/TabBar/components/Tab/Tab.module.scss
+++ b/src/components/TabBar/components/Tab/Tab.module.scss
@@ -72,7 +72,7 @@
     gap: 0;
 
     :global(body.apple) & {
-        padding: 6px 0 7px;
+        padding: 6px 0 8px;
     }
 
     svg,

--- a/src/components/TabBar/components/Tab/Tab.module.scss
+++ b/src/components/TabBar/components/Tab/Tab.module.scss
@@ -71,6 +71,10 @@
     padding: 8px 0;
     gap: 0;
 
+    :global(body.apple) & {
+        padding: 6px 0 7px;
+    }
+
     svg,
     path,
     .icon {

--- a/src/components/TabBar/components/Tab/Tab.module.scss
+++ b/src/components/TabBar/components/Tab/Tab.module.scss
@@ -65,3 +65,19 @@
         border-radius: 100px;
     }
 }
+
+.compact {
+    max-width: 90px;
+    padding: 8px 0;
+    gap: 0;
+
+    svg,
+    path,
+    .icon {
+        height: 32px;
+    }
+
+    :global(body.apple) &:not(:first-child) {
+        margin-left: 0;
+    }
+}

--- a/src/components/TabBar/components/Tab/index.js
+++ b/src/components/TabBar/components/Tab/index.js
@@ -16,6 +16,7 @@ const Tab = ({
     className = "",
     activeSegmentTime,
     activeSegment,
+    compact = false,
     ...rest
 }) => {
     const showLottie = Boolean(lottieIcon)
@@ -79,7 +80,7 @@ const Tab = ({
             layout
             transition={{ type: "spring", stiffness: 800, damping: 50 }}
             {...rest}
-            className={`${styles.tab} ${isActive ? styles.active : ""} ${className}`.trim()}
+            className={`${styles.tab} ${compact ? styles.compact : ""} ${isActive ? styles.active : ""} ${className}`.trim()}
             onClick={onClick}
         >
             <m.div layout className={styles.icon}>
@@ -96,9 +97,11 @@ const Tab = ({
                     icon
                 )}
             </m.div>
-            <m.span layout style={{ display: "inline-block" }}>
-                {label}
-            </m.span>
+            {!compact && (
+                <m.span layout style={{ display: "inline-block" }}>
+                    {label}
+                </m.span>
+            )}
         </m.div>
     )
 }
@@ -113,6 +116,7 @@ Tab.propTypes = {
     className: PropTypes.string,
     activeSegmentTime: PropTypes.number, // Время в секундах, когда иконка становится активной
     activeSegment: PropTypes.arrayOf(PropTypes.number), // Ручная настройка сегмента [startFrame, endFrame]
+    compact: PropTypes.bool,
 }
 
 export default Tab

--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -92,11 +92,11 @@ const TabBar = ({
     const playKey = `${activeIndex}:${replayNonce}`
 
     const [rootWidth, setRootWidth] = useState(0)
-    const [viewportWidth, setViewportWidth] = useState(0)
+    const [rootHeight, setRootHeight] = useState(0)
 
     useResizeObserver(rootRef, (entry) => {
-        setRootWidth(entry.target.getBoundingClientRect().width)
-        setViewportWidth(document.documentElement.clientWidth)
+        setRootWidth(entry.contentRect.width)
+        setRootHeight(entry.contentRect.height)
     })
 
     const isThreeTabs = tabs.length === 3
@@ -118,16 +118,11 @@ const TabBar = ({
             : {}),
     }
 
-    const maskSideInset =
-        rootWidth > 0 && viewportWidth > rootWidth
-            ? (viewportWidth - rootWidth) / 2
-            : marginX
-
     const maskInsets = {
         top: 21,
         bottom: 21,
-        left: maskSideInset,
-        right: maskSideInset,
+        left: marginX,
+        right: marginX,
     }
 
     return (
@@ -172,8 +167,9 @@ const TabBar = ({
             <Activity mode={isApple ? "visible" : "hidden"}>
                 <GradientMask
                     width={rootWidth}
-                    height={64}
+                    height={rootHeight}
                     insets={maskInsets}
+                    innerHeight={rootHeight}
                 />
             </Activity>
         </m.div>

--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -7,6 +7,7 @@ import { GlassBorder } from "../GlassEffect"
 import * as styles from "./TabBar.module.scss"
 import Tab from "./components/Tab"
 import { useIndicatorDrag } from "./useIndicatorDrag"
+import { useScrollScale } from "./useScrollScale"
 import GradientMask from "./components/GradientMask"
 
 const TabBarOverlay = ({
@@ -15,10 +16,13 @@ const TabBarOverlay = ({
     onChange,
     onSnapToSame,
     playKey,
+    compact,
+    maxWidth,
 }) => {
     const { overlayRef, animate, transition, handlers } = useIndicatorDrag({
         tabsLength: tabs.length,
         activeIndex,
+        compact,
         spring: { type: "spring", stiffness: 800, damping: 50 },
         onSnapToSame,
         onSnapToNew: onChange,
@@ -28,6 +32,7 @@ const TabBarOverlay = ({
         <m.div
             className={styles.clipPathContainer}
             ref={overlayRef}
+            style={{ maxWidth }}
             {...handlers}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1, ...animate }}
@@ -42,6 +47,7 @@ const TabBarOverlay = ({
                     isActive={index === activeIndex}
                     onClick={() => onChange(index)}
                     playKey={playKey}
+                    compact={compact}
                     data-overlay
                     {...tab}
                 />
@@ -50,8 +56,15 @@ const TabBarOverlay = ({
     )
 }
 
-const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
+const TabBar = ({
+    tabs,
+    onChange,
+    defaultIndex = 0,
+    variant = "default",
+    collapseOnScroll = false,
+}) => {
     const { isApple } = useSkin()
+    const compact = variant === "compact"
     const [activeIndex, setActiveIndex] = useState(defaultIndex)
     const [replayNonce, setReplayNonce] = useState(0)
 
@@ -63,7 +76,11 @@ const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
         setActiveIndex((prev) => Math.min(prev, tabs.length - 1))
     }, [tabs.length])
 
+    const rootRef = useRef(null)
+    const { scale, expand } = useScrollScale(rootRef, collapseOnScroll)
+
     const handleSegmentClick = (index) => {
+        expand()
         if (index === activeIndex) {
             setReplayNonce((n) => n + 1)
         } else {
@@ -74,70 +91,85 @@ const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
 
     const playKey = `${activeIndex}:${replayNonce}`
 
-    const rootRef = useRef(null)
-
     const [rootWidth, setRootWidth] = useState(0)
+    const [viewportWidth, setViewportWidth] = useState(0)
 
     useResizeObserver(rootRef, (entry) => {
-        setRootWidth(entry.contentRect.width)
+        setRootWidth(entry.target.getBoundingClientRect().width)
+        setViewportWidth(document.documentElement.clientWidth)
     })
 
     const isThreeTabs = tabs.length === 3
     const marginX = isThreeTabs ? 54 : 21
-    const rootStyle = isApple
-        ? {
-              left: marginX,
-              right: marginX,
-              width: `calc(100% - ${marginX * 2}px)`,
-          }
-        : {}
+    const maxTabWidth = compact ? 90 : undefined
+    const maxTabsWidth = maxTabWidth ? tabs.length * maxTabWidth : undefined
+    const maxRootWidth = maxTabsWidth ? maxTabsWidth + 8 : undefined
+    const rootStyle = {
+        "--tabbar-scroll-scale": scale,
+        ...(isApple
+            ? {
+                  left: marginX,
+                  right: marginX,
+                  width: `calc(100% - ${marginX * 2}px)`,
+              }
+            : {}),
+        ...(compact
+            ? { maxWidth: maxRootWidth, marginInline: "auto" }
+            : {}),
+    }
+
+    const maskSideInset =
+        rootWidth > 0 && viewportWidth > rootWidth
+            ? (viewportWidth - rootWidth) / 2
+            : marginX
 
     const maskInsets = {
         top: 21,
         bottom: 21,
-        left: marginX,
-        right: marginX,
+        left: maskSideInset,
+        right: maskSideInset,
     }
 
     return (
         <m.div
             ref={rootRef}
             className={styles.root}
-            whileTap={{ scale: 1.02 }}
+            whileTap={compact ? undefined : { scale: 1.02 }}
             transition={{
                 scale: { type: "spring", stiffness: 800, damping: 40 },
             }}
             style={rootStyle}
             layout
         >
-            <div
-                style={{
-                    display: "flex",
-                    width: "100%",
-                    position: "relative",
-                    zIndex: 1,
-                }}
-            >
-                {tabs.map((tab, index) => (
-                    <Tab
-                        key={index}
-                        isActive={index === activeIndex}
-                        onClick={() => handleSegmentClick(index)}
-                        playKey={playKey}
-                        {...tab}
-                    />
-                ))}
+            <div className={styles.surface}>
+                <div className={styles.content} style={{ maxWidth: maxTabsWidth }}>
+                    {tabs.map((tab, index) => (
+                        <Tab
+                            key={index}
+                            isActive={index === activeIndex}
+                            onClick={() => handleSegmentClick(index)}
+                            playKey={playKey}
+                            compact={compact}
+                            {...tab}
+                        />
+                    ))}
+                </div>
+                <TabBarOverlay
+                    tabs={tabs}
+                    activeIndex={activeIndex}
+                    onChange={handleSegmentClick}
+                    onSnapToSame={() => setReplayNonce((n) => n + 1)}
+                    playKey={playKey}
+                    compact={compact}
+                    maxWidth={maxTabsWidth}
+                />
+
+                <Activity mode={isApple ? "visible" : "hidden"}>
+                    <GlassBorder />
+                </Activity>
             </div>
-            <TabBarOverlay
-                tabs={tabs}
-                activeIndex={activeIndex}
-                onChange={handleSegmentClick}
-                onSnapToSame={() => setReplayNonce((n) => n + 1)}
-                playKey={playKey}
-            />
 
             <Activity mode={isApple ? "visible" : "hidden"}>
-                <GlassBorder />
                 <GradientMask
                     width={rootWidth}
                     height={64}
@@ -152,6 +184,8 @@ TabBar.propTypes = {
     tabs: PropTypes.array.isRequired,
     onChange: PropTypes.func,
     defaultIndex: PropTypes.number,
+    variant: PropTypes.oneOf(["default", "compact"]),
+    collapseOnScroll: PropTypes.bool,
 }
 
 TabBarOverlay.propTypes = {
@@ -160,6 +194,8 @@ TabBarOverlay.propTypes = {
     onChange: PropTypes.func,
     onSnapToSame: PropTypes.func,
     playKey: PropTypes.string,
+    compact: PropTypes.bool,
+    maxWidth: PropTypes.number,
 }
 
 export default TabBar

--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -93,10 +93,12 @@ const TabBar = ({
 
     const [rootWidth, setRootWidth] = useState(0)
     const [rootHeight, setRootHeight] = useState(0)
+    const [viewportWidth, setViewportWidth] = useState(0)
 
     useResizeObserver(rootRef, (entry) => {
         setRootWidth(entry.contentRect.width)
         setRootHeight(entry.contentRect.height)
+        setViewportWidth(document.documentElement.clientWidth)
     })
 
     const isThreeTabs = tabs.length === 3
@@ -118,11 +120,16 @@ const TabBar = ({
             : {}),
     }
 
+    const maskSideInset =
+        rootWidth > 0 && viewportWidth > rootWidth
+            ? (viewportWidth - rootWidth) / 2
+            : marginX
+
     const maskInsets = {
         top: 21,
         bottom: 21,
-        left: marginX,
-        right: marginX,
+        left: maskSideInset,
+        right: maskSideInset,
     }
 
     return (

--- a/src/components/TabBar/useIndicatorDrag.js
+++ b/src/components/TabBar/useIndicatorDrag.js
@@ -5,6 +5,7 @@ import { clamp } from "../../utils/number"
 export function useIndicatorDrag({
     tabsLength,
     activeIndex,
+    compact = false,
     onSnapToSame,
     onSnapToNew,
     spring,
@@ -20,11 +21,17 @@ export function useIndicatorDrag({
 
     const segmentPercent = 100 / tabsLength
 
-    const indicatorWidth = `calc(${segmentPercent}% + 7.33px - 4px)`
-    const indicatorLeft = `calc(${segmentPercent * activeIndex}% - ${3.67 * activeIndex}px)`
+    const indicatorWidth = compact
+        ? `${segmentPercent}%`
+        : `calc(${segmentPercent}% + 7.33px - 4px)`
+    const indicatorLeft = compact
+        ? `${segmentPercent * activeIndex}%`
+        : `calc(${segmentPercent * activeIndex}% - ${3.67 * activeIndex}px)`
 
     const clipLeft = indicatorLeft
-    const clipRight = `calc(100% - (${indicatorLeft} + ${indicatorWidth}) - 2.33px * ${activeIndex})`
+    const clipRight = compact
+        ? `calc(100% - (${indicatorLeft} + ${indicatorWidth}))`
+        : `calc(100% - (${indicatorLeft} + ${indicatorWidth}) - 2.33px * ${activeIndex})`
 
     const animateClipPath =
         isDragging && dragLeftPercent != null

--- a/src/components/TabBar/useScrollScale.js
+++ b/src/components/TabBar/useScrollScale.js
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react"
+import { useMotionValue, useReducedMotion, useSpring } from "motion/react"
+
+const SCALE_RANGE_PX = 200
+const MIN_SCALE = 0.8
+const SPRING = { stiffness: 760, damping: 26, mass: 0.65 }
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+
+const findScroller = (node) => {
+    let element = node?.parentElement
+    while (element) {
+        const overflowY = getComputedStyle(element).overflowY
+        if (overflowY === "auto" || overflowY === "scroll") return element
+        element = element.parentElement
+    }
+    return null
+}
+
+const scaleForPosition = (scrollTop) => {
+    const progress = clamp(scrollTop / SCALE_RANGE_PX, 0, 1)
+    return 1 - progress * (1 - MIN_SCALE)
+}
+
+const scaleAfterScroll = (currentScale, scrollDelta) => {
+    const scaleDelta = (scrollDelta / SCALE_RANGE_PX) * (1 - MIN_SCALE)
+    return clamp(currentScale - scaleDelta, MIN_SCALE, 1)
+}
+
+export const useScrollScale = (rootRef, enabled) => {
+    const currentScaleRef = useRef(1)
+    const previousScrollTopRef = useRef(0)
+    const reducedMotion = useReducedMotion()
+    const target = useMotionValue(1)
+    const scale = useSpring(target, SPRING)
+
+    const setScale = (nextScale) => {
+        currentScaleRef.current = nextScale
+        target.set(nextScale)
+        if (reducedMotion) scale.jump(nextScale)
+    }
+
+    useEffect(() => {
+        if (!enabled) {
+            setScale(1)
+            return
+        }
+
+        const scroller = findScroller(rootRef.current)
+        if (!scroller) return
+
+        previousScrollTopRef.current = Math.max(scroller.scrollTop, 0)
+        setScale(scaleForPosition(previousScrollTopRef.current))
+
+        let frame = 0
+        const updateScale = () => {
+            if (frame) return
+            frame = requestAnimationFrame(() => {
+                frame = 0
+                const scrollTop = Math.max(scroller.scrollTop, 0)
+                const scrollDelta = scrollTop - previousScrollTopRef.current
+                previousScrollTopRef.current = scrollTop
+                setScale(
+                    scaleAfterScroll(currentScaleRef.current, scrollDelta)
+                )
+            })
+        }
+
+        scroller.addEventListener("scroll", updateScale, { passive: true })
+        return () => {
+            scroller.removeEventListener("scroll", updateScale)
+            if (frame) cancelAnimationFrame(frame)
+        }
+    }, [enabled, reducedMotion, rootRef, scale, target])
+
+    const expand = () => {
+        const scroller = findScroller(rootRef.current)
+        previousScrollTopRef.current = Math.max(scroller?.scrollTop || 0, 0)
+        setScale(1)
+    }
+
+    return { scale, expand }
+}


### PR DESCRIPTION
## Зачем

Обычный iOS-таббар сохраняет полный размер во время прокрутки и может перекрывать больше контента, чем нужно. Этот PR добавляет опциональный компактный режим: навигация остаётся доступной, а на экране становится больше места для контента.

Текущий таббар остаётся режимом по умолчанию. Компактный режим нужно включать явно.

## Как работает компактный режим

- Показывает только иконки, без подписей. Максимальная ширина одной вкладки — 90 px.
- При прокрутке вниз плавно уменьшается со 100% до 80% на участке 200 px.
- При прокрутке вверх или нажатии на вкладку возвращается к 100%.
- Масштабируется относительно нижней границы, поэтому остаётся на месте.
- Использует такую же широкую градиентную подложку, как обычный iOS-таббар. Прозрачный вырез повторяет размер и анимацию компактного таббара.
- Учитывает системную настройку уменьшения движения.

## Реализация

Компактный режим использует существующие компоненты TabBar, GlassEffect, Motion, Picker, Cell и SectionList. Подключение:

```jsx
<TabBar variant="compact" collapseOnScroll tabs={tabs} />
```

## Как посмотреть

Откройте демонстрационную страницу компонента TabBar, выберите `Compact` в настройке `Tab bar mode` и прокрутите список. Переключатель `Apple / Material` позволяет сравнить оба стиля.

## Проверка

- `yarn lint`
- `yarn build`
- Проверено уменьшение со 100% до 80% при прокрутке вниз.
- Проверен возврат к 100% при прокрутке вверх и нажатии на вкладку.
- Проверены широкая градиентная маска и переключение `Material → Apple`.
- В консоли браузера нет ошибок.
