### PR TITLE
Glass Effect: rebuild the surface as composable layers

### DIFF
--- a/src/components/Button/RegularButton/RegularButton.module.scss
+++ b/src/components/Button/RegularButton/RegularButton.module.scss
@@ -5,28 +5,39 @@
     overflow: hidden;
     isolation: isolate;
 
+    // The 0.5px lip outside the pill, in the fill's own colour. Drawn with
+    // box-shadow spread (grows the corner radius correctly), so it survives
+    // the button's own overflow clip, which only cuts children.
+    background-color: var(--button-fill, transparent);
+    box-shadow: 0 0 0 0.5px var(--button-fill, transparent);
+
     &.filled {
-        background-color: var(--tg-theme-button-color);
+        --button-fill: var(--tg-theme-button-color);
+
         color: var(--tg-theme-button-text-color);
     }
 
     &.tinted {
-        background-color: var(--secondary-button-color);
+        --button-fill: var(--secondary-button-color);
+
         color: var(--tg-theme-accent-text-color);
     }
 
     &.plain {
-        background-color: var(--tg-theme-section-bg-color);
+        --button-fill: var(--tg-theme-section-bg-color);
+
         color: var(--tg-theme-accent-text-color);
     }
 
     &.gray {
-        background-color: var(--tertiary-fill-background);
+        --button-fill: var(--tertiary-fill-background);
+
         color: var(--tg-theme-text-color);
     }
 
     &.disabled {
-        background-color: var(--button-disabled-color);
+        --button-fill: var(--button-disabled-color);
+
         color: var(--text-disabled-color);
     }
 
@@ -35,8 +46,8 @@
     // shows. Full-height coverage via inset-bottom 0.
     &.skeleton {
         --skeleton-inset-bottom: 0px;
+        --button-fill: transparent;
 
-        background-color: transparent;
         color: transparent;
         cursor: default;
     }
@@ -49,8 +60,11 @@
     // Blink/WebKit drop the rounded overflow clip for it — the gradient leaks
     // outside the pill (visible on dark backgrounds). clip-path re-applies
     // the same rounding as a compositor-level mask, which does clip it.
+    // Outset by the lip so the clip keeps the fill-coloured ring visible.
     &[data-shine="true"] {
-        clip-path: inset(0 round var(--button-radius));
+        clip-path: inset(
+            -0.5px round calc(var(--button-radius) + 0.5px)
+        );
     }
 
     &[data-shine="true"]::before {

--- a/src/components/Button/RegularButton/RegularButton.module.scss
+++ b/src/components/Button/RegularButton/RegularButton.module.scss
@@ -5,9 +5,8 @@
     overflow: hidden;
     isolation: isolate;
 
-    // The 0.5px lip outside the pill, in the fill's own colour. Drawn with
-    // box-shadow spread (grows the corner radius correctly), so it survives
-    // the button's own overflow clip, which only cuts children.
+    // A child ring would be cut by the button's own overflow; its own shadow
+    // is not.
     background-color: var(--button-fill, transparent);
     box-shadow: 0 0 0 0.5px var(--button-fill, transparent);
 

--- a/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -41,8 +41,8 @@
         border-radius: 36px;
         padding: 16px;
         background: var(--glass-tint-background);
-        backdrop-filter: blur(8px);
-        box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+        backdrop-filter: var(--glass-surface-filter);
+        box-shadow: var(--glass-surface-shadow), var(--glass-surface-contour);
 
         @supports (-apple-visual-effect: -apple-system-glass-material) {
             -apple-visual-effect: -apple-system-glass-material;

--- a/src/components/GlassEffect/GlassBorder.module.scss
+++ b/src/components/GlassEffect/GlassBorder.module.scss
@@ -1,5 +1,4 @@
 .glassBorder {
-    content: "";
     position: absolute;
     inset: 0;
     padding: 1px;
@@ -13,23 +12,22 @@
     mask-composite: exclude;
     background: linear-gradient(
         8deg,
-        rgb(255 255 255 / 0%) 0%,
-        rgb(255 255 255 / 90%) 35%,
-        rgb(255 255 255 / 90%) 65%,
-        rgb(255 255 255 / 0%) 100%
+        rgb(255 255 255 / 20%) 0%,
+        rgb(255 255 255 / 0%) 40%,
+        rgb(255 255 255 / 90%) 100%
     );
 }
 
 // Blend-free rim for backdrop-filtered surfaces: the filter isolates
 // descendant blending, so the default overlay renders as a stark white ring on
 // dark themes. The low-alpha normal blend approximates the same look.
-.glassBorder.muted {
+.glassBorder.muted,
+:global([data-glass-isolated]) .glassBorder {
     mix-blend-mode: normal;
     background: linear-gradient(
         8deg,
-        rgb(255 255 255 / 0%) 0%,
-        rgb(255 255 255 / 32%) 35%,
-        rgb(255 255 255 / 32%) 65%,
-        rgb(255 255 255 / 0%) 100%
+        rgb(255 255 255 / 8%) 0%,
+        rgb(255 255 255 / 0%) 40%,
+        rgb(255 255 255 / 32%) 100%
     );
 }

--- a/src/components/GlassEffect/GlassContainer.js
+++ b/src/components/GlassEffect/GlassContainer.js
@@ -4,22 +4,17 @@ import GlassBorder from "./GlassBorder"
 import GlassGlare from "./GlassGlare"
 
 /**
- * Frosted-glass surface: a tinted backdrop-filtered background, a shadow layer
- * that also carries the outer contour ring, a glare along the inside edges and
- * a single GlassBorder rim. With children it wraps them; with none it renders
- * overlay layers meant to fill a positioned parent. Do NOT wrap a scaling
- * element — put backdrop-filter on the scaled node itself (Safari drops the
- * filter mid-animation).
+ * Frosted-glass surface: tinted backdrop-filtered background, shadow carrying
+ * the contour ring, glare, and a single rim. With children it wraps them; with
+ * none it renders the layers into a positioned parent. Do NOT wrap a scaling
+ * element — backdrop-filter belongs on the scaled node (Safari drops it
+ * mid-animation).
  *
- * Retune it with tokens rather than by restyling the layers:
- * `--glass-tint-background`, `--glass-surface-filter`, `--glass-surface-shadow`,
- * `--glass-surface-contour`, `--glass-glare-*`.
- *
- * The blended layers (glare, rim) need to see the page to look right. An
- * ancestor owning a filter, clip-path or opacity confines them to its own
- * group, where they flatten into a dark wash and a stark white ring; such an
- * ancestor marks itself `data-glass-isolated` and the layers step down to their
- * blend-free forms on their own.
+ * Retune with tokens, never by restyling the layers: `--glass-tint-background`,
+ * `--glass-surface-filter`, `--glass-surface-shadow`, `--glass-surface-contour`,
+ * `--glass-glare-*`. An ancestor that isolates blending (filter, clip-path,
+ * opacity) marks itself `data-glass-isolated`, and the blended layers step down
+ * to their blend-free forms.
  * @example
  * <GlassContainer className={styles.bar}>{children}</GlassContainer>
  */

--- a/src/components/GlassEffect/GlassContainer.js
+++ b/src/components/GlassEffect/GlassContainer.js
@@ -1,33 +1,43 @@
 import PropTypes from "prop-types"
 import * as styles from "./GlassContainer.module.scss"
 import GlassBorder from "./GlassBorder"
+import GlassGlare from "./GlassGlare"
 
 /**
- * Frosted-glass surface (background + shadow + a single GlassBorder). With
- * children it wraps them; with none it renders overlay layers meant to fill a
- * positioned parent. Do NOT wrap a scaling element — put backdrop-filter on the
- * scaled node itself (Safari drops the filter mid-animation).
+ * Frosted-glass surface: a tinted backdrop-filtered background, a shadow layer
+ * that also carries the outer contour ring, a glare along the inside edges and
+ * a single GlassBorder rim. With children it wraps them; with none it renders
+ * overlay layers meant to fill a positioned parent. Do NOT wrap a scaling
+ * element — put backdrop-filter on the scaled node itself (Safari drops the
+ * filter mid-animation).
+ *
+ * Retune it with tokens rather than by restyling the layers:
+ * `--glass-tint-background`, `--glass-surface-filter`, `--glass-surface-shadow`,
+ * `--glass-surface-contour`, `--glass-glare-*`.
+ *
+ * The blended layers (glare, rim) need to see the page to look right. An
+ * ancestor owning a filter, clip-path or opacity confines them to its own
+ * group, where they flatten into a dark wash and a stark white ring; such an
+ * ancestor marks itself `data-glass-isolated` and the layers step down to their
+ * blend-free forms on their own.
  * @example
  * <GlassContainer className={styles.bar}>{children}</GlassContainer>
  */
 const GlassContainer = ({ children, className = "", style = {}, ...rest }) => {
-    // If no children, render as overlay only
-    if (!children) {
-        return (
-            <>
-                <div className={styles.glassBackground} aria-hidden="true" />
-                <div className={styles.glassShadow} aria-hidden="true" />
-                <GlassBorder />
-            </>
-        )
-    }
-
-    // With children, render as wrapper
-    return (
-        <div className={`${styles.root} ${className}`} style={style} {...rest}>
+    const layers = (
+        <>
             <div className={styles.glassBackground} aria-hidden="true" />
             <div className={styles.glassShadow} aria-hidden="true" />
+            <GlassGlare />
             <GlassBorder />
+        </>
+    )
+
+    if (!children) return layers
+
+    return (
+        <div className={`${styles.root} ${className}`} style={style} {...rest}>
+            {layers}
             {children}
         </div>
     )

--- a/src/components/GlassEffect/GlassContainer.module.scss
+++ b/src/components/GlassEffect/GlassContainer.module.scss
@@ -8,9 +8,8 @@
     border-radius: inherit;
     pointer-events: none;
     background: var(--glass-tint-background);
-    backdrop-filter: blur(8px);
+    backdrop-filter: var(--glass-surface-filter);
     z-index: 0;
-    will-change: transform;
     transform: translateZ(0);
     backface-visibility: hidden;
 
@@ -26,7 +25,5 @@
     border-radius: inherit;
     pointer-events: none;
     z-index: 1;
-    box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
-    will-change: transform;
-    transform: translateZ(0);
+    box-shadow: var(--glass-surface-shadow), var(--glass-surface-contour);
 }

--- a/src/components/GlassEffect/GlassEffect.showcase.js
+++ b/src/components/GlassEffect/GlassEffect.showcase.js
@@ -16,7 +16,13 @@ const wide = (slot) => `${PICSUM}/1200/400?random=${slot}`
 const tall = (slot) => `${PICSUM}/800/1600?random=${slot}`
 
 const Backdrop = ({ src }) => (
-    <Image src={src} alt="" className={styles.backdrop} />
+    <Image
+        src={src}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        className={styles.backdrop}
+    />
 )
 
 Backdrop.propTypes = {

--- a/src/components/GlassEffect/GlassEffect.showcase.module.scss
+++ b/src/components/GlassEffect/GlassEffect.showcase.module.scss
@@ -9,6 +9,8 @@
     position: relative;
     isolation: isolate;
     overflow: hidden;
+    color: rgb(255 255 255 / 92%);
+    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 
     :global(body.apple) & {
         border-radius: 26px;
@@ -32,8 +34,7 @@
     z-index: 3;
 }
 
-.stage .backdrop,
-.scrollContent .backdrop {
+.backdrop {
     position: absolute;
     inset: 0;
     z-index: 0;
@@ -51,8 +52,6 @@
     min-width: 180px;
     padding: 16px 24px;
     border-radius: 20px;
-    color: rgb(255 255 255 / 92%);
-    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }
 
 .overlayHost {
@@ -63,12 +62,9 @@
     width: 96px;
     height: 96px;
     border-radius: 28px;
-    color: rgb(255 255 255 / 92%);
-    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }
 
 .rims {
-    position: relative;
     display: flex;
     gap: 16px;
 }
@@ -81,8 +77,6 @@
     width: 104px;
     height: 96px;
     border-radius: 24px;
-    color: rgb(255 255 255 / 92%);
-    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }
 
 .rimPlain {
@@ -111,8 +105,6 @@
     gap: 12px;
     height: 620px;
     padding: 64px 20px 20px;
-    color: rgb(255 255 255 / 92%);
-    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }
 
 .scrollRow {
@@ -128,6 +120,4 @@
     align-items: center;
     justify-content: center;
     height: 48px;
-    color: rgb(255 255 255 / 92%);
-    text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }

--- a/src/components/GlassEffect/GlassGlare.js
+++ b/src/components/GlassEffect/GlassGlare.js
@@ -2,18 +2,14 @@ import PropTypes from "prop-types"
 import * as styles from "./GlassGlare.module.scss"
 
 /**
- * The light gathering along the inside edges of a glass surface: two inset
- * shadows added to what shows through with `plus-lighter`. Inset shadows
- * follow `border-radius`, so on a capsule the light hugs the curve instead of
- * cutting straight across it. Both live in one declaration, so the layer reads
- * the backdrop once. Tune through tokens: `--glass-glare-blur` sets how thick
- * each band reads, since the offset and the negative spread cancel and leave
- * the band's edge on the box edge whatever `--glass-glare-reach` is — reach
- * only pushes the side edges out of view, so raise it, never drop it below the
- * blur. `--glass-glare-color` reads as how much light is added, not as a tint.
+ * Light along the inside edges: two inset shadows added with `plus-lighter`,
+ * in one declaration so the layer reads the backdrop once. Inset shadows follow
+ * `border-radius`, so on a capsule the light hugs the curve.
  *
- * Gated on `@supports`: without `plus-lighter` the blend would fall back to
- * `normal` and paint a dark band instead of a highlight.
+ * `--glass-glare-blur` sets how thick each band reads — offset and spread
+ * cancel, so `--glass-glare-reach` only pushes the side edges out of view and
+ * must stay above the blur. `--glass-glare-color` is how much light is added,
+ * not a tint; `transparent` turns the glare off.
  * @example
  * <GlassGlare />
  */

--- a/src/components/GlassEffect/GlassGlare.js
+++ b/src/components/GlassEffect/GlassGlare.js
@@ -1,0 +1,28 @@
+import PropTypes from "prop-types"
+import * as styles from "./GlassGlare.module.scss"
+
+/**
+ * The light gathering along the inside edges of a glass surface: two inset
+ * shadows added to what shows through with `plus-lighter`. Inset shadows
+ * follow `border-radius`, so on a capsule the light hugs the curve instead of
+ * cutting straight across it. Both live in one declaration, so the layer reads
+ * the backdrop once. Tune through tokens: `--glass-glare-blur` sets how thick
+ * each band reads, since the offset and the negative spread cancel and leave
+ * the band's edge on the box edge whatever `--glass-glare-reach` is — reach
+ * only pushes the side edges out of view, so raise it, never drop it below the
+ * blur. `--glass-glare-color` reads as how much light is added, not as a tint.
+ *
+ * Gated on `@supports`: without `plus-lighter` the blend would fall back to
+ * `normal` and paint a dark band instead of a highlight.
+ * @example
+ * <GlassGlare />
+ */
+const GlassGlare = ({ className = "" }) => (
+    <div className={`${styles.glassGlare} ${className}`} aria-hidden="true" />
+)
+
+GlassGlare.propTypes = {
+    className: PropTypes.string,
+}
+
+export default GlassGlare

--- a/src/components/GlassEffect/GlassGlare.module.scss
+++ b/src/components/GlassEffect/GlassGlare.module.scss
@@ -5,22 +5,24 @@
 }
 
 .glassGlare {
-    --glass-glare-reach: 40px;
-    --glass-glare-blur: 20px;
-    --glass-glare-color: #282828;
-
     position: absolute;
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
     z-index: 2;
 
+    // Defaults belong in the fallbacks: a declaration here would outrank the
+    // value a surface inherits down, which is how these are meant to be tuned.
     @supports (mix-blend-mode: plus-lighter) {
         mix-blend-mode: plus-lighter;
         box-shadow:
-            inset 0 var(--glass-glare-reach) var(--glass-glare-blur)
-                calc(-1 * var(--glass-glare-reach)) var(--glass-glare-color),
-            inset 0 calc(-1 * var(--glass-glare-reach)) var(--glass-glare-blur)
-                calc(-1 * var(--glass-glare-reach)) var(--glass-glare-color);
+            inset 0 var(--glass-glare-reach, 40px)
+                var(--glass-glare-blur, 20px)
+                calc(-1 * var(--glass-glare-reach, 40px))
+                var(--glass-glare-color, #282828),
+            inset 0 calc(-1 * var(--glass-glare-reach, 40px))
+                var(--glass-glare-blur, 20px)
+                calc(-1 * var(--glass-glare-reach, 40px))
+                var(--glass-glare-color, #282828);
     }
 }

--- a/src/components/GlassEffect/GlassGlare.module.scss
+++ b/src/components/GlassEffect/GlassGlare.module.scss
@@ -1,0 +1,26 @@
+// Blends have nothing to read inside an isolating ancestor, where this would
+// flatten into a dark wash.
+:global([data-glass-isolated]) .glassGlare {
+    display: none;
+}
+
+.glassGlare {
+    --glass-glare-reach: 40px;
+    --glass-glare-blur: 20px;
+    --glass-glare-color: #282828;
+
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 2;
+
+    @supports (mix-blend-mode: plus-lighter) {
+        mix-blend-mode: plus-lighter;
+        box-shadow:
+            inset 0 var(--glass-glare-reach) var(--glass-glare-blur)
+                calc(-1 * var(--glass-glare-reach)) var(--glass-glare-color),
+            inset 0 calc(-1 * var(--glass-glare-reach)) var(--glass-glare-blur)
+                calc(-1 * var(--glass-glare-reach)) var(--glass-glare-color);
+    }
+}

--- a/src/components/GlassEffect/index.js
+++ b/src/components/GlassEffect/index.js
@@ -1,3 +1,4 @@
 export { default as GlassContainer } from "./GlassContainer"
 export { default as GlassBorder } from "./GlassBorder"
+export { default as GlassGlare } from "./GlassGlare"
 export { default } from "./GlassContainer"

--- a/src/components/ModalView/ModalPanel.js
+++ b/src/components/ModalView/ModalPanel.js
@@ -33,7 +33,7 @@ const ModalPanel = ({ panelRef, corners, children, ...rest }) => {
     }, [panelRef, corners])
 
     return (
-        <m.div ref={panelRef} {...rest}>
+        <m.div ref={panelRef} data-glass-isolated="" {...rest}>
             {children}
         </m.div>
     )

--- a/src/components/PanelHeader/HeaderButton.js
+++ b/src/components/PanelHeader/HeaderButton.js
@@ -16,10 +16,7 @@ export const HEADER_BUTTON_VARIANTS = [
 ]
 
 // A glass action in the panel header: a text label (auto-sized pill) or an
-// icon (44x44 square). The childless GlassContainer supplies the whole glass
-// stack; the variants only retune its tokens. Where an ancestor isolates the
-// blends — a modal panel's clip-path, a filtered popover — that ancestor marks
-// itself `data-glass-isolated` and the layers step down on their own.
+// icon (44x44 square).
 const HeaderButton = ({
     children,
     onClick,
@@ -81,6 +78,7 @@ const HeaderButton = ({
             type="button"
             className={className}
             onClick={onClick}
+            {...(variant === "overlay" && { "data-color-scheme": "dark" })}
             {...rootProps}
         >
             {content}

--- a/src/components/PanelHeader/HeaderButton.js
+++ b/src/components/PanelHeader/HeaderButton.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types"
 import * as m from "motion/react-m"
 
-import { GlassBorder } from "../GlassEffect"
+import GlassContainer from "../GlassEffect"
 import Tappable from "../Tappable"
 import Text from "../Text"
 import { useSkin } from "../../hooks/DeviceProvider"
@@ -16,9 +16,10 @@ export const HEADER_BUTTON_VARIANTS = [
 ]
 
 // A glass action in the panel header: a text label (auto-sized pill) or an
-// icon (44x44 square). Glass lives on the element itself so the tap scale
-// can't make Safari drop the backdrop-filter mid-animation; the rim lives
-// inside it, so it must stay blend-free (GlassBorder's muted variant).
+// icon (44x44 square). The childless GlassContainer supplies the whole glass
+// stack; the variants only retune its tokens. Where an ancestor isolates the
+// blends — a modal panel's clip-path, a filtered popover — that ancestor marks
+// itself `data-glass-isolated` and the layers step down on their own.
 const HeaderButton = ({
     children,
     onClick,
@@ -47,7 +48,7 @@ const HeaderButton = ({
 
     const content = (
         <>
-            {hasRim && <GlassBorder muted />}
+            {hasRim && <GlassContainer />}
             <span className={styles.content}>
                 {swap ? (
                     <span className={styles.swap}>

--- a/src/components/PanelHeader/HeaderButton.module.scss
+++ b/src/components/PanelHeader/HeaderButton.module.scss
@@ -12,6 +12,7 @@ $swap-duration: 0.2s;
     padding: 0;
     border: 0;
     border-radius: 22px;
+    background: none;
     font: inherit;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
@@ -27,8 +28,6 @@ $swap-duration: 0.2s;
     }
 }
 
-// Glass comes from the childless GlassContainer inside the button (see
-// HeaderButton.js); the variants only retune its tokens.
 .regular {
     --glass-tint-background: var(--glass-tint-raised);
 
@@ -39,12 +38,11 @@ $swap-duration: 0.2s;
     }
 }
 
-// Translucent glass for sitting over content; white glyph.
+// Over content: the button forces the dark palette on itself (HeaderButton.js)
+// rather than picking a colour of its own.
 .overlay {
-    --glass-tint-background: rgb(
-        from var(--tg-theme-section-bg-color) r g b / 10%
-    );
     --glass-surface-filter: blur(20px);
+    --glass-glare-color: transparent;
 
     color: var(--tg-theme-button-text-color);
 }

--- a/src/components/PanelHeader/HeaderButton.module.scss
+++ b/src/components/PanelHeader/HeaderButton.module.scss
@@ -24,23 +24,15 @@ $swap-duration: 0.2s;
     :global(body.material) & {
         background: none;
         box-shadow: none;
-        backdrop-filter: none;
-        -apple-visual-effect: none;
     }
 }
 
-// Glass lives on the element itself (see HeaderButton.js) so the tap scale
-// doesn't drop the backdrop-filter in Safari.
+// Glass comes from the childless GlassContainer inside the button (see
+// HeaderButton.js); the variants only retune its tokens.
 .regular {
-    background: var(--glass-tint-background);
-    box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
-    color: var(--tg-theme-text-color);
-    backdrop-filter: blur(8px);
+    --glass-tint-background: var(--glass-tint-raised);
 
-    @supports (-apple-visual-effect: -apple-system-glass-material) {
-        -apple-visual-effect: -apple-system-glass-material;
-        backdrop-filter: none;
-    }
+    color: var(--tg-theme-text-color);
 
     :global(body.material) & {
         color: var(--tg-theme-subtitle-text-color);
@@ -49,10 +41,12 @@ $swap-duration: 0.2s;
 
 // Translucent glass for sitting over content; white glyph.
 .overlay {
-    background: rgb(from var(--tg-theme-section-bg-color) r g b / 10%);
-    box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+    --glass-tint-background: rgb(
+        from var(--tg-theme-section-bg-color) r g b / 10%
+    );
+    --glass-surface-filter: blur(20px);
+
     color: var(--tg-theme-button-text-color);
-    backdrop-filter: blur(20px);
 }
 
 .secondary {

--- a/src/components/PanelHeader/PanelHeader.module.scss
+++ b/src/components/PanelHeader/PanelHeader.module.scss
@@ -1,9 +1,6 @@
 $search-easing: cubic-bezier(0.23, 1, 0.32, 1);
 $search-duration: 0.25s;
 $search-fade-duration: 0.15s;
-
-// Bar heights, read by .root (the bar) and .spacer (its stand-in under a
-// fixed pin). One source, so the two cannot drift apart.
 $bar-height: 44px;
 $bar-height-apple: 64px;
 $bar-height-material: 56px;
@@ -48,10 +45,8 @@ $bar-height-material: 56px;
     position: sticky;
 }
 
-// Fixed pin: out of the scroller's compositing chain, so the sticky-in-scroller
-// filter-kill (see glass-rim-backdrop-isolation) never arms and the header's
-// buttons can carry the full glass stack. The spacer holds the bar's place in
-// the flow.
+// Out of the scroller's compositing chain, where a sticky bar loses the blur
+// under it. Costs a spacer, since fixed leaves the flow.
 .fixed {
     position: fixed;
     left: 0;

--- a/src/components/PanelHeader/index.js
+++ b/src/components/PanelHeader/index.js
@@ -151,7 +151,6 @@ const PanelHeader = ({
         </div>
     )
 
-    // Fixed leaves the flow, so a spacer holds the bar's place in it.
     if (pin !== "fixed") return pinnedBar
 
     return (

--- a/src/components/TabBar/TabBar.module.scss
+++ b/src/components/TabBar/TabBar.module.scss
@@ -7,6 +7,9 @@
     padding-bottom: env(safe-area-inset-bottom);
 
     :global(body.apple) & {
+        --glass-tint-background: var(--glass-tint-raised);
+        --glass-surface-filter: saturate(300%) blur(8px);
+
         position: absolute;
         left: 21px;
         right: 21px;
@@ -14,14 +17,7 @@
         border-radius: 100px;
         padding: 4px;
         margin: 0;
-        background: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
-        backdrop-filter: saturate(300%) blur(8px);
-        box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
-
-        @supports (-apple-visual-effect: -apple-system-glass-material) {
-            -apple-visual-effect: -apple-system-glass-material;
-            backdrop-filter: none;
-        }
+        box-shadow: none;
     }
 
     :global(body.material) & {
@@ -47,8 +43,8 @@
         z-index: 0;
     }
 
-    // Apple already gets GlassBorder; a glass surface carries exactly one
-    // border, so the blended hairlines exist only where GlassBorder doesn't.
+    // Apple already gets a rim from GlassContainer; a glass surface carries
+    // exactly one border, so these hairlines exist only where it doesn't.
     :global(body.material) &::after {
         content: "";
         position: absolute;

--- a/src/components/TabBar/TabBar.skeleton.module.scss
+++ b/src/components/TabBar/TabBar.skeleton.module.scss
@@ -6,9 +6,9 @@
     display: flex;
     padding: 4px;
     border-radius: 100px;
-    background: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
+    background: var(--glass-tint-raised);
     backdrop-filter: saturate(300%) blur(8px);
-    box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+    box-shadow: var(--glass-surface-shadow);
 
     // Match the real TabBar .root: sit at the platform baseline, but lift via
     // --bottom-clearance when it is set (e.g. the SkinSwitcher on showcase

--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import * as m from "motion/react-m"
 import { useSkin } from "../../hooks/DeviceProvider"
 import { useResizeObserver } from "../../hooks/useResizeObserver"
-import { GlassBorder } from "../GlassEffect"
+import GlassContainer from "../GlassEffect"
 import * as styles from "./TabBar.module.scss"
 import Tab from "./components/Tab"
 import { useIndicatorDrag } from "./useIndicatorDrag"
@@ -137,7 +137,7 @@ const TabBar = ({ tabs, onChange, defaultIndex = 0 }) => {
             />
 
             <Activity mode={isApple ? "visible" : "hidden"}>
-                <GlassBorder />
+                <GlassContainer />
                 <GradientMask
                     width={rootWidth}
                     height={64}

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,7 @@ body.material {
         --background-material-regular-color-2: rgba(0, 0, 0, 0);
         --background-material-regular-blend-mode-1: normal;
         --background-material-regular-blend-mode-2: normal;
-        --glass-tint-background: rgb(255 255 255 / 0.05);
+        --glass-tint-background: rgb(153 153 153 / 17%);
     }
 }
 
@@ -157,7 +157,7 @@ body.material {
     --background-material-regular-color-2: rgba(0, 0, 0, 0);
     --background-material-regular-blend-mode-1: normal;
     --background-material-regular-blend-mode-2: normal;
-    --glass-tint-background: rgb(255 255 255 / 0.05);
+    --glass-tint-background: rgb(153 153 153 / 17%);
 }
 
 html, body {

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,11 @@
     --material-surface-shadow:
         0 1px 2px 0 rgb(0 0 0 / 8%),
         0 2px 16px 1px rgb(0 0 0 / 10%);
+
+    --glass-surface-shadow: 0 8px 48px 0 rgb(0 0 0 / 6%);
+    --glass-surface-contour: 0 0 0 0.5px rgb(0 0 0 / 14%);
+    --glass-tint-raised: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
+    --glass-surface-filter: blur(8px);
 }
 
 :root {

--- a/src/index.css
+++ b/src/index.css
@@ -25,7 +25,10 @@
         0 2px 16px 1px rgb(0 0 0 / 10%);
 
     --glass-surface-shadow: 0 8px 48px 0 rgb(0 0 0 / 6%);
-    --glass-surface-contour: 0 0 0 0.5px rgb(0 0 0 / 14%);
+    --glass-surface-contour:
+        0 0 0 0.5px rgb(0 0 0 / 6%),
+        0.5px 0 0 0 rgb(0 0 0 / 9.6%),
+        -0.5px 0 0 0 rgb(0 0 0 / 9.6%);
     --glass-tint-raised: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
     --glass-surface-filter: blur(8px);
 }

--- a/src/pages/prototypes/NewNavigation/NewNavigation.skeleton.module.scss
+++ b/src/pages/prototypes/NewNavigation/NewNavigation.skeleton.module.scss
@@ -24,9 +24,9 @@
     align-items: center;
     padding: 4px;
     border-radius: 100px;
-    background: rgb(from var(--tg-theme-section-bg-color) r g b / 70%);
+    background: var(--glass-tint-raised);
     backdrop-filter: saturate(300%) blur(8px);
-    box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+    box-shadow: var(--glass-surface-shadow);
 
     :global(body.apple) & {
         left: 21px;


### PR DESCRIPTION
Reworks the glass surface into one composable stack, in the spirit of the iOS 27 material: light from above, a soft offset shadow, a hairline contour, and a specular rim.

## Why

Glass was assembled by hand wherever it appeared. `TabBar`, `DropdownMenu` and `HeaderButton` each carried their own tint, blur, shadow and `-apple-visual-effect` switch, and the same shadow literal was copy-pasted into seven files. Retuning the material meant editing every one of them and hoping they stayed in step.

`GlassContainer` is now the single assembly. Callers set tokens; nobody restyles the layers.

## The surface

| layer | what it does |
|---|---|
| background | tint + `backdrop-filter`, swaps to the native material under `@supports (-apple-visual-effect)` |
| shadow | `0 8px 48px / 6%`, and carries the 0.5px contour ring in the same declaration |
| glare | `plus-lighter` bands hugging the top and bottom curves |
| rim | one `GlassBorder`, gradient peaking at the top edge with a faint bounce below |

Tokens: `--glass-tint-background`, `--glass-tint-raised`, `--glass-surface-filter`, `--glass-surface-shadow`, `--glass-surface-contour`, `--glass-glare-*`.

## Three constraints that shaped it

**Blends need to see the page.** They only reach it while nothing between them and it opens a stacking context, so a glass surface must not carry `z-index` or `isolation` of its own. An ancestor that does isolate — a modal panel's `clip-path`, a filtered popover — marks itself `data-glass-isolated`, and the blended layers step down to blend-free forms by inheritance. This replaces a boolean prop that no caller upstream could have threaded down to `HeaderButton`.

**The contour is ink, not a blend.** Black at 14% multiplies the backdrop by 0.86 — the same arithmetic as `plus-darker` or `brightness(0.86)`, with none of the compositing dependencies. It survives fixed, sticky and filtered hosts, and works outside WebKit, where `plus-darker` does not exist.

**Masks apply after filters.** The rim cannot be softened with `blur()` from its own element — the filter runs before the mask cuts the ring, so the edge stays crisp regardless. It is crisp by design now rather than by accident.

## Also in here

- The seven copies of the old shadow, and three copies of the `-apple-visual-effect` switch, are gone; the switch lives with the two rules that actually apply `backdrop-filter`.
- `RegularButton` gains a fill-coloured lip via `--button-fill`, which also removes the duplicated `background-color` per variant.
- A showcase at Components -> Glass Effect: four stands over photo backdrops, since the blur only reads against detail.

## Worth a look before merging

- **Safari, tapping.** `TabBar` and `HeaderButton` both animate scale, and the blur now sits on a child rather than the animated element. That is the configuration our own notes say Safari can drop mid-animation. It looked right on macOS; it has not been tried on iOS, including Low Power Mode.
- **Modal headers**, which is what `data-glass-isolated` exists for.
- **Material/desktop**, where the surfaces differ most from the Apple path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)